### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -8,6 +8,8 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
+    permissions:
+      contents: read
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/gabrown001/gab-cmdline/security/code-scanning/3](https://github.com/gabrown001/gab-cmdline/security/code-scanning/3)

To fix this issue, an explicit `permissions` block specifying the minimum permissions required should be added to the workflow or job. In the context of SonarQube analysis and building with Maven, read-only access to repository content is likely sufficient for most workflows. Add `permissions: contents: read` either at the top level of the workflow file (applies to all jobs), or specifically under the `build` job (affects only that job). Given only one job is defined, placing it at the top level is more future-proof; however, adding it under the `build` job is also correct and more precise given the flagged line.

**Best single fix:**  
Add the following under the `build` job definition (just below line 10, before `name:`):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
