### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gabrown001/gab-cmdline/security/code-scanning/2](https://github.com/gabrown001/gab-cmdline/security/code-scanning/2)

The best way to fix the problem is to explicitly add a `permissions` block to the workflow that limits the GITHUB_TOKEN's permissions according to the principle of least privilege. For this Java/Maven build workflow, the minimal required permission is typically `contents: read`, because the workflow needs to check out code, but does not push back or manage issues, etc. 

This permission block should be added at the top level of the workflow file (alongside `name` and `on`), so it applies to all jobs by default (unless jobs need more or less access). Insert the following YAML block immediately after `name: Java CI with Maven` and before the `on:` block to restrict permissions to read-only:

```yaml
permissions:
  contents: read
```

No further imports or code changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
