### PR TITLE
Make CmdLine an instance class, fix four parser sharp edges, repair the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ hs_err_pid*
 /bak/
 **/.DS_Store
 .vscode
+
+# Snyk Security Extension - AI Rules (auto-generated)
+.github/instructions/snyk_rules.instructions.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+# Build the project
+mvn package
+
+# Run all tests
+mvn test
+
+# Run a single test class
+mvn test -Dtest=CmdLineTest
+
+# Run a single test method
+mvn test -Dtest=CmdLineTest#testMethodName
+
+# Run with code coverage report (output in target/site/jacoco/)
+mvn test jacoco:report
+
+# Format code (runs automatically on build via formatter-maven-plugin)
+mvn formatter:format
+
+# Run SpotBugs static analysis
+mvn spotbugs:check
+
+# Skip tests during build
+mvn package -DskipTests
+```
+
+Requirements: Java 17, Maven 3.9.0+
+
+## Architecture Overview
+
+This is a lightweight Java command-line argument parser library (`com.gabstudios.cmdline`). The library uses a static-singleton pattern — `CmdLine` is a utility class with only static methods and a singleton `INSTANCE` for method chaining.
+
+### Parse Flow
+
+1. **Define**: Call `CmdLine.defineCommand("...")` to register command definitions. Each definition string is tokenized by `CommandDefinitionTokenizer` into `Token` objects. The resulting `CommandDefinition` is stored in a static `HashMap<String, CommandDefinition>`.
+
+2. **Parse**: Call `CmdLine.parse(args)` or `CmdLine.parse(args, listener)`. The raw `String[]` args are split on `=` and `,` into a flat token list. Tokens are consumed recursively — the first token is matched against the command definition map, and subsequent tokens are consumed as variable values.
+
+3. **Output**: Returns a `List<Command>`, each `Command` holding its name and a `Map<String, List<String>>` of named variable values.
+
+4. **Clear**: Call `CmdLine.clear()` to reset all static state before reuse.
+
+### Definition Token Syntax (processed by `CommandDefinitionTokenizer`)
+
+| Prefix | Token Type | Notes |
+|--------|-----------|-------|
+| *(none)* | `COMMAND` | Command name (e.g., `-help`, `--file`) |
+| `#` | `DESCRIPTION` | Human-readable description; max one per command |
+| `!` | `REQUIRED_VALUE` | Required variable; must precede optional variables |
+| `?` | `OPTIONAL_VALUE` | Optional variable |
+| `!name...` | `REQUIRED_LIST_VALUE` | Required variable that consumes remaining tokens |
+| `?name...` | `OPTIONAL_LIST_VALUE` | Optional variable that consumes remaining tokens |
+| `:` | `REGEX_VALUE` | Regex pattern to validate variable values; max one per command |
+
+### Key Classes
+
+- **`CmdLine`** — Static entry point. Holds all state in static fields (definition map, variable name set, command list, trie for suggestions). Manages `-D<key>=<value>` system property syntax automatically.
+- **`CommandDefinitionTokenizer`** — Converts `defineCommand()` string args into `Token` objects using prefix-based switching.
+- **`CommandDefinition`** — POJO storing names, required/optional variable lists, optional regex, and description for one logical command.
+- **`Command`** — POJO returned after parsing; holds the matched command name and a map of variable name → `List<String>` values.
+- **`CommandListener`** — Single-method interface (`handle(Command)`) for callback-based processing during parse.
+- **`Token` / `Token.Type`** — Internal enum-typed value object used during definition tokenization.
+- **Exceptions** — All extend `RuntimeException`: `DuplicateException` (duplicate command/variable), `MissingException` (required variable absent), `MatchException` (regex mismatch), `UnsupportedException` (unknown command; includes `getSuggestionList()` for typo suggestions).
+
+### `com.gabstudios.collection` package
+
+Contains a general-purpose trie used internally for word suggestion when an undefined command is encountered:
+- **`Trie`** — Interface with `add`, `contains`, `getWords(prefix)`, `getWords()`, `clear`.
+- **`LinkedHashMapTree`** — Generic tree backed by `LinkedHashMap` for ordered children.
+- **`LinkedHashMapTrie`** — Implements `Trie` on top of `LinkedHashMapTree<Character>`. Each character is a tree node; `TrieNode.isWord()` marks word terminals.
+
+### Static State & Thread Safety
+
+`CmdLine` is **not thread-safe** — all state (definition map, variable name set, parsed command list, command listener) lives in static fields. Always call `CmdLine.clear()` between test cases (tests use `@AfterEach` for this). The class is non-instantiable (private constructor).
+
+### Variable Name Uniqueness
+
+Variable names (from `!` and `?` tokens) are **globally unique across all commands** — tracked in a static `HashSet<String>`. Reusing the same variable name in different `defineCommand()` calls throws `DuplicateException`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,24 +34,24 @@ Requirements: Java 17, Maven 3.9.0+
 
 ## Architecture Overview
 
-This is a lightweight Java command-line argument parser library (`com.gabstudios.cmdline`). The library uses a static-singleton pattern — `CmdLine` is a utility class with only static methods and a singleton `INSTANCE` for method chaining.
+This is a lightweight Java command-line argument parser library (`com.gabstudios.cmdline`). `CmdLine` is an ordinary class: construct one with `new CmdLine()` and call instance methods on it. Instances share no state, so two parsers can coexist and a test builds one per case rather than clearing a global.
 
 ### Parse Flow
 
-1. **Define**: Call `CmdLine.defineCommand("...")` to register command definitions. Each definition string is tokenized by `CommandDefinitionTokenizer` into `Token` objects. The resulting `CommandDefinition` is stored in a static `HashMap<String, CommandDefinition>`.
+1. **Define**: Call `cmdLine.defineCommand("...")` to register command definitions. Each definition string is split on commas **up to the first `#`**; everything from `#` onward is the description, kept whole. The tokens are turned into `Token` objects by `CommandDefinitionTokenizer` and the resulting `CommandDefinition` is stored in the instance's map.
 
-2. **Parse**: Call `CmdLine.parse(args)` or `CmdLine.parse(args, listener)`. The raw `String[]` args are split on `=` and `,` into a flat token list. Tokens are consumed recursively — the first token is matched against the command definition map, and subsequent tokens are consumed as variable values.
+2. **Parse**: Call `cmdLine.parse(args)` or `cmdLine.parse(args, listener)`. The raw `String[]` args are split on `=` and `,` into a flat token list. Tokens are consumed recursively — the first token is matched against the command definition map, and subsequent tokens are consumed as variable values. An **empty array yields an empty list**, not an exception: running a tool with no arguments is its most common invocation. A `listener` applies only to the parse it is passed to.
 
 3. **Output**: Returns a `List<Command>`, each `Command` holding its name and a `Map<String, List<String>>` of named variable values.
 
-4. **Clear**: Call `CmdLine.clear()` to reset all static state before reuse.
+4. **Clear**: Call `cmdLine.clear()` to reset one parser for reuse. Usually unnecessary — construct a new one instead.
 
 ### Definition Token Syntax (processed by `CommandDefinitionTokenizer`)
 
 | Prefix | Token Type | Notes |
 |--------|-----------|-------|
 | *(none)* | `COMMAND` | Command name (e.g., `-help`, `--file`) |
-| `#` | `DESCRIPTION` | Human-readable description; max one per command |
+| `#` | `DESCRIPTION` | Human-readable description; max one per command. In a single comma-delimited definition it runs to the end of the string, so it may contain commas and `=` |
 | `!` | `REQUIRED_VALUE` | Required variable; must precede optional variables |
 | `?` | `OPTIONAL_VALUE` | Optional variable |
 | `!name...` | `REQUIRED_LIST_VALUE` | Required variable that consumes remaining tokens |
@@ -60,7 +60,7 @@ This is a lightweight Java command-line argument parser library (`com.gabstudios
 
 ### Key Classes
 
-- **`CmdLine`** — Static entry point. Holds all state in static fields (definition map, variable name set, command list, trie for suggestions). Manages `-D<key>=<value>` system property syntax automatically.
+- **`CmdLine`** — The parser. Holds all state in instance fields (definition map, parsed command list, listener, application name, version, trie for suggestions). Manages `-D<key>=<value>` system property syntax automatically.
 - **`CommandDefinitionTokenizer`** — Converts `defineCommand()` string args into `Token` objects using prefix-based switching.
 - **`CommandDefinition`** — POJO storing names, required/optional variable lists, optional regex, and description for one logical command.
 - **`Command`** — POJO returned after parsing; holds the matched command name and a map of variable name → `List<String>` values.
@@ -75,10 +75,27 @@ Contains a general-purpose trie used internally for word suggestion when an unde
 - **`LinkedHashMapTree`** — Generic tree backed by `LinkedHashMap` for ordered children.
 - **`LinkedHashMapTrie`** — Implements `Trie` on top of `LinkedHashMapTree<Character>`. Each character is a tree node; `TrieNode.isWord()` marks word terminals.
 
-### Static State & Thread Safety
+### State & Thread Safety
 
-`CmdLine` is **not thread-safe** — all state (definition map, variable name set, parsed command list, command listener) lives in static fields. Always call `CmdLine.clear()` between test cases (tests use `@AfterEach` for this). The class is non-instantiable (private constructor).
+State lives on the instance, so two parsers are independent. A single instance is **not thread-safe** — its collections are unsynchronized — so do not share one across threads; give each thread its own.
+
+Tests construct a parser per case rather than clearing a global.
 
 ### Variable Name Uniqueness
 
-Variable names (from `!` and `?` tokens) are **globally unique across all commands** — tracked in a static `HashSet<String>`. Reusing the same variable name in different `defineCommand()` calls throws `DuplicateException`.
+Variable names (from `!` and `?` tokens) are unique **within one command**, not across all of them. Two commands may each declare a `!file`; declaring `!file` twice in one definition throws `DuplicateException`.
+
+Values are read back by variable name: `command.getValues("file")`.
+
+### Chaining
+
+`defineCommand` and the setters return the instance, so calls chain:
+
+```java
+CmdLine cmdLine = new CmdLine();
+cmdLine.defineCommand("-f, --file, !name, #Load a file")
+       .defineCommand("-s, --save, #Save the file")
+       .setApplicationName("mytool");
+```
+
+Because these are instance methods, chaining is clean under `-Xlint:static` — a consumer building with `-Werror` no longer has to break the chain apart.

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,5 +1,5 @@
    
-   Copyright 2016 Gregory Brown
+   Copyright 2016-2025 Gregory Brown
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ Use Maven to build - `mvn package`.
 Usage
 ---------
 
-In order to parse the command line, you need to define what the commands are by calling `Cmdline.defineCommand("xxx");`
+Construct a parser, then define what the commands are by calling `defineCommand("xxx")` on it.
 
 ```java
-CmdLine.defineCommand("-help, #print this message")
+CmdLine cmdLine = new CmdLine();
+cmdLine.defineCommand("-help, #print this message");
 ```
+
+Instances share no state, so two parsers can coexist and a test can build one per case
+rather than clearing a global.
 
 The string used in the defineCommand() method, contains tokens that must use one of these symbols in order for it to be recognized as that type:
 
@@ -53,6 +57,18 @@ The string used in the defineCommand() method, contains tokens that must use one
 ... = A value ends with ... and is a list for the command name. There can be zero to one defined. This can be used with the ! and ? symbols
 
 If a token does not start with one of these tokens, then it is considered a command name.  There can be one to many  names that represent a single command, such as: 'f', 'file', 'filename' or '-f', '--file', '--filename'.
+
+Three things are worth knowing before you write your first definition:
+
+* **The description runs to the end of the definition.** Everything from the first `#` is
+  description, so it may contain commas and equals signs.
+
+* **A value name is scoped to its command.** Two commands may each declare a `!file`.
+  Values are read back by that name, not by the option that carried them —
+  `--upload, !file` is read as `command.getValues("file")`.
+
+* **Parsing no arguments is not an error.** `parse(new String[0])` returns an empty list,
+  so an application that shows help in that case does not have to special-case it first.
 
 Example
 ---------
@@ -89,7 +105,8 @@ final CmdLineListener listener = new CmdLineListener();
 // define/declare the commands the parser should parse.
 // command names can start with any character that is not reserved.  reserved are !?#:
 // the commands listed below use the - (dash) to denote a command, but this is not required.
-CmdLine.defineCommand("-help, #print this message")
+CmdLine cmdLine = new CmdLine();
+cmdLine.defineCommand("-help, #print this message")
        .defineCommand("-version, #print the version information and exit")
        .defineCommand("-quiet, #be extra quiet")
        .defineCommand("-verbose, #be extra verbose")
@@ -104,7 +121,7 @@ If a -D<property>=<value> is seen on the command line, it is parsed and set
 in the System properties.  In addition, a command is created and sent to the listener.
 
 // parse the command line args and pass matching commands to the listener for processing.
-final List<command> = CmdLine.parse( args, listener );
+final List<Command> commands = cmdLine.parse( args, listener );
 ```
 Click for more [examples].
 

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -164,7 +164,7 @@ public class CmdLine {
      * Clears the CmdLine and releases resources. Resets all state including command definitions, the command listener,
      * system properties support (disabled), and any previously parsed commands.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      */
     public CmdLine clear() {
         this.commandListener = null;
@@ -339,7 +339,7 @@ public class CmdLine {
      * @param nameArgs
      *            An array of String containing values.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      */
     public CmdLine defineCommand(final String... nameArgs) {
         if (!(nameArgs != null && nameArgs.length > 0 && nameArgs.length <= CmdLine.MAX_LENGTH)) {
@@ -379,7 +379,7 @@ public class CmdLine {
      * @param nameArgs
      *            A comma-delimited string containing the command definition tokens.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      *
      * @throws IllegalArgumentException
      *             if nameArgs is null, empty, or exceeds the maximum length.
@@ -701,7 +701,7 @@ public class CmdLine {
      * @param name
      *            The name of the application. Must not be null or empty, and must not exceed the maximum length.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      *
      * @throws IllegalArgumentException
      *             if name is null, empty, or exceeds the maximum length.
@@ -723,7 +723,7 @@ public class CmdLine {
      * @param enabled
      *            true to enable {@code -D} system property processing, false to disable.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      */
     public CmdLine setSystemPropertiesEnabled(final boolean enabled) {
         this.systemPropertiesEnabled = enabled;
@@ -736,7 +736,7 @@ public class CmdLine {
      * @param commandListener
      *            A listener that will handle the callbacks.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      */
     public CmdLine setCommandListener(final CommandListener commandListener) {
         if (commandListener == null) {
@@ -753,7 +753,7 @@ public class CmdLine {
      * @param version
      *            A String value. Must not be null or empty.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return this parser, so calls can be chained.
      *
      * @throws IllegalArgumentException
      *             if version is null or empty.

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -46,9 +46,9 @@ import com.gabstudios.collection.Trie;
  * There can be zero to many defined. : = The regex value to match on for any values that are defined. There can be zero
  * to one defined. If a String does not use one of the above char, then it is considered a command.
  *
- * @see setCommandListener
- * @see defineCommand
- * @see parse
+ * @see CmdLine#setCommandListener(CommandListener)
+ * @see CmdLine#defineCommand(String)
+ * @see CmdLine#parse(String[])
  *
  * @author G Brown
  */
@@ -60,7 +60,7 @@ public class CmdLine {
     private static final Map<String, CommandDefinition> COMMAND_DEFINITION_MAP;
 
     /*
-     * The listener that will handle commands as they are processed, to the main cmdline class.
+     * Accumulates the Command instances produced during a parse() call.
      */
     private static final List<Command> DEFAULT_COMMAND_LIST;
 
@@ -124,9 +124,6 @@ public class CmdLine {
      */
     private static final Set<String> BLOCKED_KEY_PREFIXES = Set.of("java.", "javax.", "sun.", "jdk.", "com.sun.");
 
-    /**
-     * The CmdLine constructor.
-     */
     static {
         WORD_SUGGESTION_TRIE = new LinkedHashMapTrie();
         COMMAND_DEFINITION_MAP = new HashMap<>();
@@ -234,7 +231,7 @@ public class CmdLine {
             final Type type = token.getType();
             final String name = token.getValue();
             switch (type) {
-                case COMMAND: {
+                case COMMAND -> {
                     if (name.contains(" ")) {
                         throw (new UnsupportedException("Error: The command name '" + name
                                 + "' contains spaces which is not supported.  " + "The definition may need a comma."));
@@ -242,10 +239,8 @@ public class CmdLine {
                         command.addName(name);
                         CmdLine.WORD_SUGGESTION_TRIE.add(name);
                     }
-                    break;
                 }
-                case DESCRIPTION: {
-
+                case DESCRIPTION -> {
                     final String description = command.getDescription();
                     if ((description != null) && (description.length() > 0)) {
                         throw (new DuplicateException(
@@ -253,19 +248,16 @@ public class CmdLine {
                     } else {
                         command.setDescription(name);
                     }
-
-                    break;
                 }
-                case REGEX_VALUE: {
+                case REGEX_VALUE -> {
                     final String existingRegex = command.getRegexValue();
                     if ((existingRegex != null) && (existingRegex.length() > 0)) {
                         throw (new DuplicateException("Error: The regex '" + name + "' has already been defined."));
                     } else {
                         command.setRegexValue(name);
                     }
-                    break;
                 }
-                case REQUIRED_VALUE: {
+                case REQUIRED_VALUE -> {
                     if (isOptionalVarDefined) {
                         throw (new UnsupportedException(
                                 "Error: An optional variable has already been defined before this required variable.  "
@@ -274,9 +266,8 @@ public class CmdLine {
                         CmdLine.addVariableName(name);
                         command.addRequiredVariable(name);
                     }
-                    break;
                 }
-                case REQUIRED_LIST_VALUE: {
+                case REQUIRED_LIST_VALUE -> {
                     if (isOptionalVarDefined) {
                         throw (new UnsupportedException(
                                 "Error: An optional variable has already been defined before this required variable.  "
@@ -289,15 +280,13 @@ public class CmdLine {
                         CmdLine.addVariableName(name);
                         command.setRequiredVariableList(name);
                     }
-                    break;
                 }
-                case OPTIONAL_VALUE: {
+                case OPTIONAL_VALUE -> {
                     CmdLine.addVariableName(name);
                     command.addOptionalVariable(name);
                     isOptionalVarDefined = true;
-                    break;
                 }
-                case OPTIONAL_LIST_VALUE: {
+                case OPTIONAL_LIST_VALUE -> {
                     if (doesListExist) {
                         throw (new UnsupportedException("Error: A List has already been defined for '" + name
                                 + "'.  A command can only have one list defined. "));
@@ -307,12 +296,9 @@ public class CmdLine {
                         command.setOptionalVariableList(name);
                         isOptionalVarDefined = true;
                     }
-                    break;
                 }
-                default: {
-                    throw (new UnsupportedException(
-                            "Error:  Unknown token '" + name + "' is an unknown type ='" + type.name() + "')."));
-                }
+                default -> throw (new UnsupportedException(
+                        "Error:  Unknown token '" + name + "' is an unknown type ='" + type.name() + "')."));
             }
         }
 
@@ -330,7 +316,7 @@ public class CmdLine {
      * can be zero to many defined. ? = An optional value for the command name. There can be zero to many defined. : =
      * The regex value to match on for any values that are defined. There can be zero to one defined. ... = A value ends
      * with ... and is a list for the command name. There can be zero to one defined. This can be used with the ! and ?
-     * symbols If a token does not start with one of these tokens, then it is considered a command name. Exmaples:
+     * symbols If a token does not start with one of these tokens, then it is considered a command name. Examples:
      * "file, !fileName1, :file\\d.txt, #Load a files into the system" "-f, --file, !fileName1, ?fileName2, ?fileName3,
      * :file\\d.txt, #Load a files into the system" "-f, --file, !fileName1, ?fileNames..., #Load a files into the
      * system"
@@ -484,8 +470,7 @@ public class CmdLine {
 
             // Have all tokens been consumed?
             if (!tokens.isEmpty()) {
-                // Reclusive call and process the remaining
-                // tokens.
+                // Recursive call to process the remaining tokens.
                 CmdLine.processCmdLineTokens(tokens);
             }
 
@@ -604,14 +589,9 @@ public class CmdLine {
                 // System.out.println("processVariable: " + name + " : "
                 // + argToken + " = " + _variableNameSet);
 
-                boolean isMatch = true;
-                if (pattern != null) {
-                    final Matcher matcher = pattern.matcher(argToken);
-                    isMatch = matcher.matches();
-                    if (!isMatch) {
-                        throw (new MatchException("Error:  The value '" + argToken
-                                + "' does not match the expected pattern '" + pattern.toString() + "'."));
-                    }
+                if (pattern != null && !pattern.matcher(argToken).matches()) {
+                    throw (new MatchException("Error:  The value '" + argToken
+                            + "' does not match the expected pattern '" + pattern.toString() + "'."));
                 }
 
                 if (CmdLine.VARIABLE_NAME_SET.contains(varName)) {
@@ -675,9 +655,12 @@ public class CmdLine {
      * Sets the application name in the cmdline. To be used in the help menu - (future release).
      *
      * @param name
-     *            The name of the application.
+     *            The name of the application. Must not be null or empty, and must not exceed the maximum length.
      *
      * @return The CmdLine instance. Used for chaining calls.
+     *
+     * @throws IllegalArgumentException
+     *             if name is null, empty, or exceeds the maximum length.
      */
     public static CmdLine setApplicationName(final String name) {
         if (name == null || name.isEmpty() || name.length() > CmdLine.MAX_LENGTH) {
@@ -727,6 +710,9 @@ public class CmdLine {
      *            A String value. Must not be null or empty.
      *
      * @return The CmdLine instance. Used for chaining calls.
+     *
+     * @throws IllegalArgumentException
+     *             if version is null or empty.
      */
     public static CmdLine setVersion(final String version) {
         if (version == null || version.isEmpty()) {
@@ -738,7 +724,7 @@ public class CmdLine {
     }
 
     /*
-     * Converts the command line args.into String tokens.
+     * Converts the command line args into String tokens.
      */
     protected static List<String> tokenize(final String[] args) {
         assert (args != null && args.length > 0) : "The parameter 'args' must not be null or empty";

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -50,7 +50,7 @@ import com.gabstudios.collection.Trie;
  * @see defineCommand
  * @see parse
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class CmdLine {
 
@@ -114,6 +114,16 @@ public class CmdLine {
     private static final String NAME_LESS_EQUAL_ERROR = "The parameter 'name' must be less than or equal to "
             + CmdLine.MAX_LENGTH;
 
+    /*
+     * Controls whether -D<key>=<value> tokens are processed as System properties. Disabled by default.
+     */
+    private static boolean s_systemPropertiesEnabled = false;
+
+    /*
+     * Property key prefixes that may not be set via the command line.
+     */
+    private static final Set<String> BLOCKED_KEY_PREFIXES = Set.of("java.", "javax.", "sun.", "jdk.", "com.sun.");
+
     /**
      * The CmdLine constructor.
      */
@@ -141,12 +151,14 @@ public class CmdLine {
     }
 
     /**
-     * Clears the CmdLine and releases resources.
+     * Clears the CmdLine and releases resources. Resets all state including command definitions, the command listener,
+     * system properties support (disabled), and any previously parsed commands.
      *
      * @return The CmdLine instance. Used for chaining calls.
      */
     public static CmdLine clear() {
         CmdLine.s_commandListener = null;
+        CmdLine.s_systemPropertiesEnabled = false;
         CmdLine.COMMAND_DEFINITION_MAP.clear();
         CmdLine.VARIABLE_NAME_SET.clear();
         CmdLine.WORD_SUGGESTION_TRIE.clear();
@@ -350,21 +362,17 @@ public class CmdLine {
     }
 
     /**
-     * This method defines the command definitions expected in the parser. Call this method for each command that will
-     * be defined. A token must use one of these symbols in order for it to be recognized as that type: # = The
-     * description of the command. There may be zero to one defined. ! = A required value for the command name. There
-     * can be zero to many defined. ? = An optional value for the command name. There can be zero to many defined. : =
-     * The regex value to match on for any values that are defined. There can be zero to one defined. ... = A value ends
-     * with ... and is a list for the command name. There can be zero to one defined. This can be used with the ! and ?
-     * symbols If a token does not start with one of these tokens, then it is considered a command name. Exmaples:
-     * "file, !fileName1, :file\\d.txt, #Load a files into the system" "-f, --file, !fileName1, ?fileName2, ?fileName3,
-     * :file\\d.txt, #Load a files into the system" "-f, --file, !fileName1, ?fileNames..., #Load a files into the
-     * system"
+     * Convenience overload of {@link #defineCommand(String...)} that accepts a single comma-delimited string. The
+     * string is split on commas before processing, so {@code "-f, --file, !name, #desc"} is equivalent to calling
+     * {@code defineCommand("-f", "--file", "!name", "#desc")}.
      *
      * @param nameArgs
-     *            A comma delimited String containing values.
+     *            A comma-delimited string containing the command definition tokens.
      *
      * @return The CmdLine instance. Used for chaining calls.
+     *
+     * @throws IllegalArgumentException
+     *             if nameArgs is null, empty, or exceeds the maximum length.
      */
     public static CmdLine defineCommand(final String nameArgs) {
         if (nameArgs == null || nameArgs.isEmpty() || nameArgs.length() > CmdLine.MAX_LENGTH) {
@@ -400,7 +408,16 @@ public class CmdLine {
      * @param args
      *            The arguments from the command line.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return A list of {@link Command} instances created from the parsed arguments.
+     *
+     * @throws IllegalArgumentException
+     *             if args is null, empty, or exceeds the maximum length.
+     * @throws UnsupportedException
+     *             if an unrecognized command token is encountered.
+     * @throws MissingException
+     *             if a required variable value is absent.
+     * @throws MatchException
+     *             if a value does not match the defined regex pattern.
      */
     public static List<Command> parse(final String[] args) {
         if (!(args != null && args.length > 0 && args.length <= CmdLine.MAX_LENGTH)) {
@@ -415,14 +432,24 @@ public class CmdLine {
     }
 
     /**
-     * Parse the command line arguments.
+     * Parse the command line arguments, notifying the provided listener for each command found.
      *
      * @param args
      *            The arguments from the command line.
      * @param commandListener
-     *            A listener that will handle the callbacks.
+     *            A {@link CommandListener} that will be called for each {@link Command} created during parsing. Must
+     *            not be null.
      *
-     * @return The CmdLine instance. Used for chaining calls.
+     * @return A list of {@link Command} instances created from the parsed arguments.
+     *
+     * @throws IllegalArgumentException
+     *             if args is null, empty, or exceeds the maximum length, or if commandListener is null.
+     * @throws UnsupportedException
+     *             if an unrecognized command token is encountered.
+     * @throws MissingException
+     *             if a required variable value is absent.
+     * @throws MatchException
+     *             if a value does not match the defined regex pattern.
      */
     public static List<Command> parse(final String[] args, final CommandListener commandListener) {
         CmdLine.setCommandListener(commandListener);
@@ -483,19 +510,43 @@ public class CmdLine {
     }
 
     /*
-     * Processes the -D<property>=<value> and adds it to the System property.
+     * Processes the -D<property>=<value> and adds it to the System property. Only runs when system property processing
+     * has been explicitly enabled via setSystemPropertiesEnabled(true).
      */
-    @SuppressWarnings("SizeReplaceableByIsEmpty")
     private static boolean processSystemProperty(final String valueString, final List<String> tokens) {
 
+        if (!CmdLine.s_systemPropertiesEnabled) {
+            return false;
+        }
+
         boolean isSystemPropertyProcessed = false;
-        if ((valueString != null) && (tokens != null) && (tokens.size() > 0)) {
+        if ((valueString != null) && (tokens != null) && !tokens.isEmpty()) {
             final int indexOfSystemProperty = valueString.indexOf("-D");
 
             if (indexOfSystemProperty > -1) {
                 final String systemPropertyKey = valueString.substring(indexOfSystemProperty + 2);
 
+                if (systemPropertyKey.isEmpty() || systemPropertyKey.length() > CmdLine.MAX_LENGTH) {
+                    throw new IllegalArgumentException(
+                            "Error: The -D property key must not be empty and must be less than or equal to "
+                                    + CmdLine.MAX_LENGTH + " characters.");
+                }
+
+                for (final String blockedPrefix : CmdLine.BLOCKED_KEY_PREFIXES) {
+                    if (systemPropertyKey.startsWith(blockedPrefix)) {
+                        throw new UnsupportedException(
+                                "Error: The -D property key '" + systemPropertyKey + "' uses a reserved prefix '"
+                                        + blockedPrefix + "' and cannot be set via the command line.");
+                    }
+                }
+
                 final String systemPropertyValue = tokens.remove(0);
+
+                if (systemPropertyValue.isEmpty() || systemPropertyValue.length() > CmdLine.MAX_LENGTH) {
+                    throw new IllegalArgumentException(
+                            "Error: The -D property value must not be empty and must be less than or equal to "
+                                    + CmdLine.MAX_LENGTH + " characters.");
+                }
 
                 isSystemPropertyProcessed = true;
                 System.setProperty(systemPropertyKey, systemPropertyValue);
@@ -506,8 +557,6 @@ public class CmdLine {
                 CmdLine.DEFAULT_COMMAND_LIST.add(command);
 
                 if (CmdLine.s_commandListener != null) {
-                    // TODO - thread call to remove from main thread. add
-                    // timeout for processing.
                     CmdLine.s_commandListener.handle(command);
                 }
             }
@@ -636,6 +685,21 @@ public class CmdLine {
         }
 
         CmdLine.s_applicationName = name;
+        return (CmdLine.INSTANCE);
+    }
+
+    /**
+     * Enables or disables automatic processing of {@code -D<key>=<value>} tokens as System properties. Disabled by
+     * default. When enabled, keys matching any prefix in {@code BLOCKED_KEY_PREFIXES} are rejected with an
+     * {@link UnsupportedException}.
+     *
+     * @param enabled
+     *            true to enable {@code -D} system property processing, false to disable.
+     *
+     * @return The CmdLine instance. Used for chaining calls.
+     */
+    public static CmdLine setSystemPropertiesEnabled(final boolean enabled) {
+        CmdLine.s_systemPropertiesEnabled = enabled;
         return (CmdLine.INSTANCE);
     }
 

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -36,11 +36,11 @@ import com.gabstudios.collection.Trie;
 
 /**
  * This class is the main command line parser. Steps to use parser. 1. Define your command definitions.
- * CmdLine.defineCommand("-l, --load, !fileName, #Load a files into the system") .defineCommand("-s, --save, #Save the
+ * this.defineCommand("-l, --load, !fileName, #Load a files into the system") .defineCommand("-s, --save, #Save the
  * application"); .defineCommand("-q, --quit, #Quit the application"); 2. parse the command line arguments and assign a
- * listener for command definitions CmdLine.parse( args, listener ); or parse the command line arguments and get the
- * returned List of Command instances. List commands = CmdLine.parse( args ); 3. clear parser to release resources.
- * CmdLine.clear(); CmdLine.defineCommand("xxxx") uses a token based on the first char. If a String uses one of these
+ * listener for command definitions this.parse( args, listener ); or parse the command line arguments and get the
+ * returned List of Command instances. List commands = this.parse( args ); 3. clear parser to release resources.
+ * CmdLine.clear(); this.defineCommand("xxxx") uses a token based on the first char. If a String uses one of these
  * symbols then it is recognized as that type: # = The description of the command. There may be zero to one defined. ! =
  * A required value for the command name. There can be zero to many defined. ? = An optional value for the command name.
  * There can be zero to many defined. : = The regex value to match on for any values that are defined. There can be zero
@@ -57,12 +57,12 @@ public class CmdLine {
     /*
      * A map that holds the key of a command string and a value of a command definition.
      */
-    private static final Map<String, CommandDefinition> COMMAND_DEFINITION_MAP;
+    private final Map<String, CommandDefinition> commandDefinitionMap;
 
     /*
      * Accumulates the Command instances produced during a parse() call.
      */
-    private static final List<Command> DEFAULT_COMMAND_LIST;
+    private final List<Command> parsedCommands;
 
     /*
      * Regex to split the define command method
@@ -75,40 +75,35 @@ public class CmdLine {
     private static final CommandDefinitionTokenizer DEFINED_COMMAND_TOKENIZER;
 
     /*
-     * Support method chaining.
-     */
-    private static final CmdLine INSTANCE;
-
-    /*
      * The maximum length allowed for any size - String, tokens, etc.
      */
     private static final int MAX_LENGTH = 256;
 
     /*
+     * The maximum number of command line arguments accepted. Separate from MAX_LENGTH, which bounds the length of a
+     * single string: they are different limits and one constant cannot explain both in an error message.
+     */
+    private static final int MAX_ARGUMENTS = 256;
+
+    /*
      * The application name.
      */
-    private static String s_applicationName;
+    private String applicationName;
 
     /*
      * The listener that will handle commands as they are processed, if it is set. May be 0 to 1.
      */
-    private static CommandListener s_commandListener;
+    private CommandListener commandListener;
 
     /*
      * The application version.
      */
-    private static String s_version;
-
-    /*
-     * Holds the variable names assigned to commands. Variable names are unique across commands. One a variable is used
-     * by a command, another command *may not use* that same variable name.
-     */
-    private static final Set<String> VARIABLE_NAME_SET;
+    private String version;
 
     /*
      * A Trie that holds the command names. This data structure is used for word suggestion if the command is not found.
      */
-    private static final Trie WORD_SUGGESTION_TRIE;
+    private final Trie wordSuggestionTrie;
 
     private static final String NAME_NULL_EMPTY_ERROR = "The parameter 'name' must not be null or empty.";
     private static final String NAME_LESS_EQUAL_ERROR = "The parameter 'name' must be less than or equal to "
@@ -117,7 +112,7 @@ public class CmdLine {
     /*
      * Controls whether -D<key>=<value> tokens are processed as System properties. Disabled by default.
      */
-    private static boolean s_systemPropertiesEnabled = false;
+    private boolean systemPropertiesEnabled;
 
     /*
      * Property key prefixes that may not be set via the command line.
@@ -125,25 +120,21 @@ public class CmdLine {
     private static final Set<String> BLOCKED_KEY_PREFIXES = Set.of("java.", "javax.", "sun.", "jdk.", "com.sun.");
 
     static {
-        WORD_SUGGESTION_TRIE = new LinkedHashMapTrie();
-        COMMAND_DEFINITION_MAP = new HashMap<>();
-        VARIABLE_NAME_SET = new HashSet<>();
         DEFINED_COMMAND_TOKENIZER = new CommandDefinitionTokenizer();
-        DEFAULT_COMMAND_LIST = new ArrayList<>();
-        INSTANCE = new CmdLine();
     }
 
     /*
-     * Adds variable name to existing set. If the name already exists, then the DuplicateException is thrown.
+     * Records a variable name within ONE command definition. Names are scoped to the command that declares them, so two
+     * commands may each take a "!file"; declaring the same name twice in one definition is still a duplicate.
      */
-    private static void addVariableName(final String name) {
+    private static void addVariableName(final Set<String> namesInThisCommand, final String name) {
         assert ((name != null) && (name.length() > 0)) : NAME_NULL_EMPTY_ERROR;
         assert (name.length() <= CmdLine.MAX_LENGTH)
                 : "The parameter 'name' must be less than or equal to " + CmdLine.MAX_LENGTH;
 
-        if (!CmdLine.VARIABLE_NAME_SET.add(name)) {
-            throw (new DuplicateException(
-                    "Error: The variable '" + name + "' has already been defined.  Define a new variable name."));
+        if (!namesInThisCommand.add(name)) {
+            throw (new DuplicateException("Error: The variable '" + name
+                    + "' has already been defined for this command.  Define a new variable name."));
         }
     }
 
@@ -153,20 +144,19 @@ public class CmdLine {
      *
      * @return The CmdLine instance. Used for chaining calls.
      */
-    public static CmdLine clear() {
-        CmdLine.s_commandListener = null;
-        CmdLine.s_systemPropertiesEnabled = false;
-        CmdLine.COMMAND_DEFINITION_MAP.clear();
-        CmdLine.VARIABLE_NAME_SET.clear();
-        CmdLine.WORD_SUGGESTION_TRIE.clear();
-        CmdLine.DEFAULT_COMMAND_LIST.clear();
-        return (CmdLine.INSTANCE);
+    public CmdLine clear() {
+        this.commandListener = null;
+        this.systemPropertiesEnabled = false;
+        this.commandDefinitionMap.clear();
+        this.wordSuggestionTrie.clear();
+        this.parsedCommands.clear();
+        return (this);
     }
 
     /*
      * Creates the Command if a CommandDefinition exists.
      */
-    private static Command createCommand(final String commandName, final List<String> tokens) {
+    private Command createCommand(final String commandName, final List<String> tokens) {
 
         assert ((commandName != null) && (commandName.length() > 0))
                 : "The parameter 'commandName' must not be null or empty";
@@ -176,7 +166,7 @@ public class CmdLine {
 
         final Command command = new Command(commandName);
         if (!tokens.isEmpty()) {
-            final CommandDefinition commandDefinition = CmdLine.COMMAND_DEFINITION_MAP.get(commandName);
+            final CommandDefinition commandDefinition = this.commandDefinitionMap.get(commandName);
 
             final String regex = commandDefinition.getRegexValue();
             Pattern pattern = null;
@@ -186,22 +176,22 @@ public class CmdLine {
 
             if (commandDefinition.hasRequiredVariables()) {
                 final List<String> names = commandDefinition.getRequiredVariableNames();
-                CmdLine.processVariable(pattern, tokens, names, command, true);
+                this.processVariable(pattern, tokens, names, command, true);
             }
 
             if (commandDefinition.hasRequiredVariableLists()) {
                 final String name = commandDefinition.getRequiredVariableListName();
-                CmdLine.processVariableList(pattern, tokens, name, command, true);
+                this.processVariableList(pattern, tokens, name, command, true);
             }
 
             if (commandDefinition.hasOptionalVariables()) {
                 final List<String> names = commandDefinition.getOptionalVariableNames();
-                CmdLine.processVariable(pattern, tokens, names, command, false);
+                this.processVariable(pattern, tokens, names, command, false);
             }
 
             if (commandDefinition.hasOptionalVariableLists()) {
                 final String name = commandDefinition.getOptionalVariableListName();
-                CmdLine.processVariableList(pattern, tokens, name, command, false);
+                this.processVariableList(pattern, tokens, name, command, false);
             }
         }
 
@@ -211,13 +201,16 @@ public class CmdLine {
     /*
      * Creates a CommandDefinition.
      */
-    private static CommandDefinition createCommandDefinition(final List<Token> tokens) {
+    private CommandDefinition createCommandDefinition(final List<Token> tokens) {
 
         assert ((tokens != null) && (!tokens.isEmpty())) : "The parameter 'tokens' must not be null or empty";
         assert (tokens.size() <= CmdLine.MAX_LENGTH)
                 : "The parameter 'name' must be less than or equal to " + CmdLine.MAX_LENGTH;
 
         final CommandDefinition command = new CommandDefinition();
+
+        // Variable names are unique within one command, not across all of them.
+        final Set<String> variableNames = new HashSet<>();
 
         // a list flag. Only one list can exist.
         boolean doesListExist = false;
@@ -237,7 +230,7 @@ public class CmdLine {
                                 + "' contains spaces which is not supported.  " + "The definition may need a comma."));
                     } else {
                         command.addName(name);
-                        CmdLine.WORD_SUGGESTION_TRIE.add(name);
+                        this.wordSuggestionTrie.add(name);
                     }
                 }
                 case DESCRIPTION -> {
@@ -263,7 +256,7 @@ public class CmdLine {
                                 "Error: An optional variable has already been defined before this required variable.  "
                                         + "Required variables must be defined before optional variables.'"));
                     } else {
-                        CmdLine.addVariableName(name);
+                        CmdLine.addVariableName(variableNames, name);
                         command.addRequiredVariable(name);
                     }
                 }
@@ -277,12 +270,12 @@ public class CmdLine {
                                 + "'.  A command can only have one list defined. "));
                     } else {
                         doesListExist = true;
-                        CmdLine.addVariableName(name);
+                        CmdLine.addVariableName(variableNames, name);
                         command.setRequiredVariableList(name);
                     }
                 }
                 case OPTIONAL_VALUE -> {
-                    CmdLine.addVariableName(name);
+                    CmdLine.addVariableName(variableNames, name);
                     command.addOptionalVariable(name);
                     isOptionalVarDefined = true;
                 }
@@ -292,7 +285,7 @@ public class CmdLine {
                                 + "'.  A command can only have one list defined. "));
                     } else {
                         doesListExist = true;
-                        CmdLine.addVariableName(name);
+                        CmdLine.addVariableName(variableNames, name);
                         command.setOptionalVariableList(name);
                         isOptionalVarDefined = true;
                     }
@@ -326,25 +319,34 @@ public class CmdLine {
      *
      * @return The CmdLine instance. Used for chaining calls.
      */
-    public static CmdLine defineCommand(final String... nameArgs) {
+    public CmdLine defineCommand(final String... nameArgs) {
         if (!(nameArgs != null && nameArgs.length > 0 && nameArgs.length <= CmdLine.MAX_LENGTH)) {
             throw new IllegalArgumentException("Invalid command definition arguments");
         }
 
         final List<Token> tokens = CmdLine.DEFINED_COMMAND_TOKENIZER.tokenize(nameArgs);
 
-        final CommandDefinition command = CmdLine.createCommandDefinition(tokens);
+        // Checked here rather than deeper down: createCommandDefinition takes a
+        // non-empty token list as an invariant, and a definition made only of
+        // whitespace should be reported as the caller's error rather than
+        // reaching an internal assertion.
+        if (tokens.isEmpty()) {
+            throw (new UnsupportedException(
+                    "Error: The definition is empty.  A definition must contain at least " + "one command name."));
+        }
+
+        final CommandDefinition command = this.createCommandDefinition(tokens);
         final List<String> names = command.getNames();
 
         for (final String name : names) {
-            final CommandDefinition existingCommand = CmdLine.COMMAND_DEFINITION_MAP.put(name, command);
+            final CommandDefinition existingCommand = this.commandDefinitionMap.put(name, command);
             if (existingCommand != null) {
                 throw (new DuplicateException(
                         "Error: The command '" + name + "' has already been defined.  Define a new command name."));
             }
         }
 
-        return (CmdLine.INSTANCE);
+        return (this);
     }
 
     /**
@@ -360,14 +362,13 @@ public class CmdLine {
      * @throws IllegalArgumentException
      *             if nameArgs is null, empty, or exceeds the maximum length.
      */
-    public static CmdLine defineCommand(final String nameArgs) {
+    public CmdLine defineCommand(final String nameArgs) {
         if (nameArgs == null || nameArgs.isEmpty() || nameArgs.length() > CmdLine.MAX_LENGTH) {
             throw new IllegalArgumentException("Invalid command definition string");
         }
 
-        final String[] nameArgTokens = nameArgs.split(CmdLine.DEFINED_COMMAND_REGEX_PARSE_PATTERN);
-        CmdLine.defineCommand(nameArgTokens);
-        return (CmdLine.INSTANCE);
+        this.defineCommand(CmdLine.splitDefinition(nameArgs));
+        return (this);
     }
 
     /**
@@ -375,8 +376,8 @@ public class CmdLine {
      *
      * @return A String. May be null or empty if the application name was not defined.
      */
-    public static String getApplicationName() {
-        return (CmdLine.s_applicationName);
+    public String getApplicationName() {
+        return (this.applicationName);
     }
 
     /**
@@ -384,8 +385,8 @@ public class CmdLine {
      *
      * @return A String. May be null or empty if the version was not defined.
      */
-    public static String getVersion() {
-        return (CmdLine.s_version);
+    public String getVersion() {
+        return (this.version);
     }
 
     /**
@@ -397,7 +398,8 @@ public class CmdLine {
      * @return A list of {@link Command} instances created from the parsed arguments.
      *
      * @throws IllegalArgumentException
-     *             if args is null, empty, or exceeds the maximum length.
+     *             if args is null or exceeds the maximum number of arguments. An empty array is not an error and yields
+     *             an empty list.
      * @throws UnsupportedException
      *             if an unrecognized command token is encountered.
      * @throws MissingException
@@ -405,16 +407,27 @@ public class CmdLine {
      * @throws MatchException
      *             if a value does not match the defined regex pattern.
      */
-    public static List<Command> parse(final String[] args) {
-        if (!(args != null && args.length > 0 && args.length <= CmdLine.MAX_LENGTH)) {
-            throw new IllegalArgumentException("Invalid arguments array");
+    public List<Command> parse(final String[] args) {
+        if (args == null) {
+            throw new IllegalArgumentException("The arguments array must not be null");
+        }
+        if (args.length > CmdLine.MAX_ARGUMENTS) {
+            throw new IllegalArgumentException(
+                    "The arguments array must hold at most " + CmdLine.MAX_ARGUMENTS + " entries");
+        }
+        // Running a tool with no arguments is its most common invocation, and
+        // an application that wants to show help then should not have to
+        // special-case it before calling.
+        if (args.length == 0) {
+            this.parsedCommands.clear();
+            return (new ArrayList<>());
         }
 
-        CmdLine.DEFAULT_COMMAND_LIST.clear();
+        this.parsedCommands.clear();
         final List<String> tokens = CmdLine.tokenize(args);
-        CmdLine.processCmdLineTokens(tokens);
+        this.processCmdLineTokens(tokens);
 
-        final List<Command> commands = new ArrayList<>(CmdLine.DEFAULT_COMMAND_LIST);
+        final List<Command> commands = new ArrayList<>(this.parsedCommands);
         return (commands);
     }
 
@@ -423,14 +436,14 @@ public class CmdLine {
      *
      * @param args
      *            The arguments from the command line.
-     * @param commandListener
-     *            A {@link CommandListener} that will be called for each {@link Command} created during parsing. Must
-     *            not be null.
+     * @param listener
+     *            A {@link CommandListener} that will be called for each {@link Command} created during parsing. Applies
+     *            to this call only; it is not retained for later parses.
      *
      * @return A list of {@link Command} instances created from the parsed arguments.
      *
      * @throws IllegalArgumentException
-     *             if args is null, empty, or exceeds the maximum length, or if commandListener is null.
+     *             if args is null or exceeds the maximum number of arguments.
      * @throws UnsupportedException
      *             if an unrecognized command token is encountered.
      * @throws MissingException
@@ -438,15 +451,23 @@ public class CmdLine {
      * @throws MatchException
      *             if a value does not match the defined regex pattern.
      */
-    public static List<Command> parse(final String[] args, final CommandListener commandListener) {
-        CmdLine.setCommandListener(commandListener);
-        return (CmdLine.parse(args));
+    public List<Command> parse(final String[] args, final CommandListener listener) {
+        // Applied for THIS parse only. Leaving it set meant a later parse(args)
+        // still notified a listener the caller had passed once, which is
+        // surprising at a distance and hard to trace.
+        final CommandListener previous = this.commandListener;
+        this.commandListener = listener;
+        try {
+            return (this.parse(args));
+        } finally {
+            this.commandListener = previous;
+        }
     }
 
     /*
      * Processes the String tokens and creates Command.
      */
-    private static void processCmdLineTokens(final List<String> tokens) {
+    private void processCmdLineTokens(final List<String> tokens) {
 
         assert ((tokens != null) && (!tokens.isEmpty())) : "The parameter 'tokens' must not be null or empty";
         assert (tokens.size() <= CmdLine.MAX_LENGTH)
@@ -455,42 +476,42 @@ public class CmdLine {
         final String tokenValue = tokens.remove(0);
 
         // check to see that a command definition exists for the current token.
-        if (CmdLine.COMMAND_DEFINITION_MAP.containsKey(tokenValue)) {
+        if (this.commandDefinitionMap.containsKey(tokenValue)) {
             // if defined, then create a command.
-            final Command command = CmdLine.createCommand(tokenValue, tokens);
+            final Command command = this.createCommand(tokenValue, tokens);
 
-            CmdLine.DEFAULT_COMMAND_LIST.add(command);
+            this.parsedCommands.add(command);
 
             // if the listener was set, then notify the listener of the created
             // command.
-            if (CmdLine.s_commandListener != null) {
+            if (this.commandListener != null) {
                 // TODO - thread call to remove from main thread. add timeout
                 // for processing.
-                CmdLine.s_commandListener.handle(command);
+                this.commandListener.handle(command);
             }
 
             // Have all tokens been consumed?
             if (!tokens.isEmpty()) {
                 // Recursive call to process the remaining tokens.
-                CmdLine.processCmdLineTokens(tokens);
+                this.processCmdLineTokens(tokens);
             }
 
         } else {
             // Process -D<property>=<value> if it exists.
-            final boolean processForSystemProperty = CmdLine.processSystemProperty(tokenValue, tokens);
+            final boolean processForSystemProperty = this.processSystemProperty(tokenValue, tokens);
 
             // if not processed, then the token is not supported.
             if (!processForSystemProperty) {
                 // if tokenvalue and not a system property then it is not
                 // defined.
-                final List<String> suggestedWords = CmdLine.WORD_SUGGESTION_TRIE.getWords(tokenValue);
+                final List<String> suggestedWords = this.wordSuggestionTrie.getWords(tokenValue);
 
                 throw (new UnsupportedException("Error: The command name '" + tokenValue + "' is not defined.",
                         suggestedWords));
             } else if (!tokens.isEmpty()) {
                 // if the token is supported, recursive call and process the
                 // remaining tokens.
-                CmdLine.processCmdLineTokens(tokens);
+                this.processCmdLineTokens(tokens);
             }
         }
     }
@@ -499,9 +520,9 @@ public class CmdLine {
      * Processes the -D<property>=<value> and adds it to the System property. Only runs when system property processing
      * has been explicitly enabled via setSystemPropertiesEnabled(true).
      */
-    private static boolean processSystemProperty(final String valueString, final List<String> tokens) {
+    private boolean processSystemProperty(final String valueString, final List<String> tokens) {
 
-        if (!CmdLine.s_systemPropertiesEnabled) {
+        if (!this.systemPropertiesEnabled) {
             return false;
         }
 
@@ -540,10 +561,10 @@ public class CmdLine {
                 final Command command = new Command(valueString);
                 command.addVariable(systemPropertyKey, systemPropertyValue);
 
-                CmdLine.DEFAULT_COMMAND_LIST.add(command);
+                this.parsedCommands.add(command);
 
-                if (CmdLine.s_commandListener != null) {
-                    CmdLine.s_commandListener.handle(command);
+                if (this.commandListener != null) {
+                    this.commandListener.handle(command);
                 }
             }
         }
@@ -553,7 +574,7 @@ public class CmdLine {
     /*
      * Process the required and optional variables that are associated with a command.
      */
-    private static void processVariable(final Pattern pattern, final List<String> tokens,
+    private void processVariable(final Pattern pattern, final List<String> tokens,
             final List<String> definedVariableNames, final Command command, final boolean required) {
 
         // pattern can be null.
@@ -595,9 +616,9 @@ public class CmdLine {
                             + "' does not match the expected pattern '" + pattern.toString() + "'."));
                 }
 
-                if (CmdLine.VARIABLE_NAME_SET.contains(varName)) {
-                    command.addVariable(varName, argToken);
-                }
+                // varName came from this command's own definition, so it is a
+                // variable of this command by construction.
+                command.addVariable(varName, argToken);
             }
         }
     }
@@ -605,7 +626,7 @@ public class CmdLine {
     /*
      * Process the required and optional variable lists that are associated with a command.
      */
-    private static void processVariableList(final Pattern pattern, final List<String> tokens, final String varName,
+    private void processVariableList(final Pattern pattern, final List<String> tokens, final String varName,
             final Command command, final boolean required) {
         // pattern can be null.
 
@@ -627,14 +648,14 @@ public class CmdLine {
             // variable is required then throw exception.
             throw (new MissingException("Error:  The value for the required variable '" + varName + "' is missing."));
         } else {
-            while (!tokens.isEmpty() && !CmdLine.COMMAND_DEFINITION_MAP.containsKey(tokens.get(0))) {
+            while (!tokens.isEmpty() && !this.commandDefinitionMap.containsKey(tokens.get(0))) {
 
                 final String argToken = tokens.remove(0);
 
                 // Process -Dsystem.properties=true if on command line.
-                final boolean processedSystemProperty = CmdLine.processSystemProperty(argToken, tokens);
+                final boolean processedSystemProperty = this.processSystemProperty(argToken, tokens);
 
-                if (!processedSystemProperty && CmdLine.VARIABLE_NAME_SET.contains(varName)) {
+                if (!processedSystemProperty) {
 
                     if (pattern != null) {
                         final Matcher matcher = pattern.matcher(argToken);
@@ -663,13 +684,13 @@ public class CmdLine {
      * @throws IllegalArgumentException
      *             if name is null, empty, or exceeds the maximum length.
      */
-    public static CmdLine setApplicationName(final String name) {
+    public CmdLine setApplicationName(final String name) {
         if (name == null || name.isEmpty() || name.length() > CmdLine.MAX_LENGTH) {
             throw new IllegalArgumentException("Invalid application name");
         }
 
-        CmdLine.s_applicationName = name;
-        return (CmdLine.INSTANCE);
+        this.applicationName = name;
+        return (this);
     }
 
     /**
@@ -682,9 +703,9 @@ public class CmdLine {
      *
      * @return The CmdLine instance. Used for chaining calls.
      */
-    public static CmdLine setSystemPropertiesEnabled(final boolean enabled) {
-        CmdLine.s_systemPropertiesEnabled = enabled;
-        return (CmdLine.INSTANCE);
+    public CmdLine setSystemPropertiesEnabled(final boolean enabled) {
+        this.systemPropertiesEnabled = enabled;
+        return (this);
     }
 
     /**
@@ -695,13 +716,13 @@ public class CmdLine {
      *
      * @return The CmdLine instance. Used for chaining calls.
      */
-    public static CmdLine setCommandListener(final CommandListener commandListener) {
+    public CmdLine setCommandListener(final CommandListener commandListener) {
         if (commandListener == null) {
             throw new IllegalArgumentException("CommandListener cannot be null");
         }
 
-        CmdLine.s_commandListener = commandListener;
-        return (CmdLine.INSTANCE);
+        this.commandListener = commandListener;
+        return (this);
     }
 
     /**
@@ -715,13 +736,39 @@ public class CmdLine {
      * @throws IllegalArgumentException
      *             if version is null or empty.
      */
-    public static CmdLine setVersion(final String version) {
+    public CmdLine setVersion(final String version) {
         if (version == null || version.isEmpty()) {
             throw new IllegalArgumentException("Version cannot be null or empty");
         }
 
-        CmdLine.s_version = version;
-        return (CmdLine.INSTANCE);
+        this.version = version;
+        return (this);
+    }
+
+    /*
+     * Splits a comma-delimited definition, stopping at the description. Everything from the first '#' to the end of the
+     * string is one token. The description is prose, and prose contains commas: "#List imports, newest first" used to
+     * split into a description and a second command named "newest first", reported as an error about spaces that named
+     * neither the comma nor the description. An '=' in a description had the same effect.
+     */
+    private static String[] splitDefinition(final String definition) {
+        final int hash = definition.indexOf('#');
+        if (hash < 0) {
+            return (definition.split(CmdLine.DEFINED_COMMAND_REGEX_PARSE_PATTERN));
+        }
+
+        final String beforeDescription = definition.substring(0, hash);
+        final String description = definition.substring(hash).trim();
+
+        final List<String> parts = new ArrayList<>();
+        for (final String part : beforeDescription.split(CmdLine.DEFINED_COMMAND_REGEX_PARSE_PATTERN)) {
+            final String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                parts.add(trimmed);
+            }
+        }
+        parts.add(description);
+        return (parts.toArray(new String[0]));
     }
 
     /*
@@ -740,8 +787,21 @@ public class CmdLine {
                 .collect(Collectors.toList()); // Collect into a List<String>
     }
 
-    private CmdLine() {
-        // block direct instance
+    /**
+     * Creates an independent parser.
+     * <p>
+     * Instances share no state: definitions, parsed commands, the listener, the application name and version, and the
+     * system-property switch all belong to the instance. Two parsers can coexist in one JVM, and a test can build one
+     * per case instead of clearing a global.
+     * <p>
+     * The static methods on this class operate on a single shared instance and remain available for simple programs.
+     * Prefer an instance when chaining: the static methods return this type for backward compatibility, so chaining off
+     * them invokes a static method through an expression, which {@code -Xlint:static} reports.
+     */
+    public CmdLine() {
+        this.wordSuggestionTrie = new LinkedHashMapTrie();
+        this.commandDefinitionMap = new HashMap<>();
+        this.parsedCommands = new ArrayList<>();
     }
 
 }

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -410,6 +410,7 @@ public class CmdLine {
             throw new IllegalArgumentException("Invalid arguments array");
         }
 
+        CmdLine.DEFAULT_COMMAND_LIST.clear();
         final List<String> tokens = CmdLine.tokenize(args);
         CmdLine.processCmdLineTokens(tokens);
 

--- a/src/main/java/com/gabstudios/cmdline/CmdLine.java
+++ b/src/main/java/com/gabstudios/cmdline/CmdLine.java
@@ -35,20 +35,42 @@ import com.gabstudios.collection.LinkedHashMapTrie;
 import com.gabstudios.collection.Trie;
 
 /**
- * This class is the main command line parser. Steps to use parser. 1. Define your command definitions.
- * this.defineCommand("-l, --load, !fileName, #Load a files into the system") .defineCommand("-s, --save, #Save the
- * application"); .defineCommand("-q, --quit, #Quit the application"); 2. parse the command line arguments and assign a
- * listener for command definitions this.parse( args, listener ); or parse the command line arguments and get the
- * returned List of Command instances. List commands = this.parse( args ); 3. clear parser to release resources.
- * CmdLine.clear(); this.defineCommand("xxxx") uses a token based on the first char. If a String uses one of these
- * symbols then it is recognized as that type: # = The description of the command. There may be zero to one defined. ! =
- * A required value for the command name. There can be zero to many defined. ? = An optional value for the command name.
- * There can be zero to many defined. : = The regex value to match on for any values that are defined. There can be zero
- * to one defined. If a String does not use one of the above char, then it is considered a command.
+ * The command line parser.
+ * <p>
+ * Construct one, define the commands it should recognise, then parse. Instances share no state, so two parsers can
+ * coexist and a test can build one per case:
  *
- * @see CmdLine#setCommandListener(CommandListener)
+ * <pre>
+ * CmdLine cmdLine = new CmdLine();
+ * cmdLine.defineCommand("-l, --load, !fileName, #Load a file into the system")
+ *         .defineCommand("-s, --save, #Save the application").defineCommand("-q, --quit, #Quit the application");
+ *
+ * // Either hand each command to a listener as it is found...
+ * cmdLine.parse(args, listener);
+ *
+ * // ...or take the list back.
+ * List&lt;Command&gt; commands = cmdLine.parse(args);
+ * </pre>
+ * <p>
+ * A definition is split on commas, and each token is read by its first character:
+ * <ul>
+ * <li>{@code #} the description. Zero or one. In a single comma-delimited definition it runs to the end of the string,
+ * so it may itself contain commas and equals signs.</li>
+ * <li>{@code !} a required value. Zero to many, and all must precede any optional value.</li>
+ * <li>{@code ?} an optional value. Zero to many.</li>
+ * <li>{@code :} a regex every value of this command must match. Zero or one.</li>
+ * <li>A token starting with none of these is a command name. One command may have several.</li>
+ * </ul>
+ * <p>
+ * A value name is scoped to the command that declares it, so two commands may each take a {@code !file}, and values are
+ * read back by that name: {@code command.getValues("file")}.
+ * <p>
+ * An empty argument array yields an empty list rather than an error — running a tool with no arguments is its most
+ * common invocation. A listener passed to {@link #parse(String[], CommandListener)} applies to that call only.
+ *
  * @see CmdLine#defineCommand(String)
  * @see CmdLine#parse(String[])
+ * @see CmdLine#parse(String[], CommandListener)
  *
  * @author G Brown
  */

--- a/src/main/java/com/gabstudios/cmdline/Command.java
+++ b/src/main/java/com/gabstudios/cmdline/Command.java
@@ -39,13 +39,13 @@ public class Command {
     /*
      * The name of the command
      */
-    protected String _name;
+    private final String _name;
 
     /*
      * The variables associated with the command. A variable has a name and value. The value is held in a
      * <code>List</code> instance.
      */
-    protected Map<String, List> _variables;
+    private final Map<String, List<String>> _variables;
 
     /**
      * A Command POJO. Associates a name and creates the data structure that holds the variables.
@@ -81,10 +81,8 @@ public class Command {
 
         List<String> variables;
         if (!this._variables.containsKey(name)) {
-            // create list
             variables = new LinkedList<>();
             this._variables.put(name, variables);
-
         } else {
             variables = this._variables.get(name);
         }
@@ -132,10 +130,7 @@ public class Command {
      */
     public List<String> getValues(final String name) {
         final List<String> commandValues = this._variables.get(name);
-
-        // wrap the values into another container so that it is immutable.
-        final List<String> values = (commandValues != null ? new ArrayList<>(commandValues) : new ArrayList<>());
-        return (values);
+        return (commandValues != null ? new ArrayList<>(commandValues) : new ArrayList<>());
     }
 
     @Override

--- a/src/main/java/com/gabstudios/cmdline/Command.java
+++ b/src/main/java/com/gabstudios/cmdline/Command.java
@@ -27,9 +27,9 @@ import java.util.Map;
 
 /**
  * This class is the command that is created when the command line is parsed. It is sent to the
- * CommandListener.handle(Command command) method. It holds the name and variables of the command.
+ * {@link CommandListener#handle(Command)} method. It holds the name and variables of the command.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class Command {
 
@@ -48,7 +48,7 @@ public class Command {
     protected Map<String, List> _variables;
 
     /**
-     * A Command POJO. Associates a name and creates the data structure that holds the variables.F
+     * A Command POJO. Associates a name and creates the data structure that holds the variables.
      *
      * @param name
      *            The name of the command.
@@ -61,16 +61,23 @@ public class Command {
     }
 
     /**
-     * Adds a variable to the Command. The value is added to a <code>List</code> .
+     * Adds a variable to the Command. The value is added to a <code>List</code>, allowing multiple values per name.
      *
      * @param name
-     *            The name of the Variable. Must be unique.
+     *            The name of the variable. Must not be null or empty.
      * @param value
-     *            The value associated with the name.
+     *            The value associated with the name. Must not be null or empty.
+     *
+     * @throws IllegalArgumentException
+     *             if name or value is null or empty.
      */
     public void addVariable(final String name, final String value) {
-        assert ((name != null) && (name.length() > 0)) : NAME_ERROR_STRING;
-        assert ((value != null) && (value.length() > 0)) : VALUE_ERROR_STRING;
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException(NAME_ERROR_STRING);
+        }
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException(VALUE_ERROR_STRING);
+        }
 
         List<String> variables;
         if (!this._variables.containsKey(name)) {
@@ -84,10 +91,6 @@ public class Command {
         variables.add(value);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -111,9 +114,9 @@ public class Command {
     }
 
     /**
-     * Gets the name
+     * Gets the command name as it appeared on the command line (e.g. {@code "-f"}, {@code "--file"}).
      *
-     * @return A String name.
+     * @return The command name string. Never null.
      */
     public String getName() {
         return (this._name);
@@ -125,7 +128,7 @@ public class Command {
      * @param name
      *            The name of the variable to get the values for.
      *
-     * @return A new List instance holding one to many Strings.
+     * @return A new List instance holding the values. Returns an empty list if the variable name is not found.
      */
     public List<String> getValues(final String name) {
         final List<String> commandValues = this._variables.get(name);
@@ -135,10 +138,6 @@ public class Command {
         return (values);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -150,16 +149,12 @@ public class Command {
     /**
      * A test to see if the Command has any variables associated with it.
      *
-     * @return A boolean value. True if the Command has variables, otherwise it is false.F
+     * @return A boolean value. True if the Command has variables, otherwise it is false.
      */
     public boolean hasVariables() {
         return (!this._variables.isEmpty());
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return String.format("Command [_name=%s, _variables=%s]", this._name, this._variables);

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
@@ -61,18 +61,30 @@ public class CommandDefinition {
     }
 
     protected void addOptionalVariable(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Name cannot be null or empty");
+        }
         this._optionalVariables.add(name);
     }
 
     protected void setOptionalVariableList(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Name cannot be null or empty");
+        }
         this._optionalVariableListName = name;
     }
 
     protected void addRequiredVariable(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Name cannot be null or empty");
+        }
         this._requiredVariables.add(name);
     }
 
     protected void setRequiredVariableList(final String name) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Name cannot be null or empty");
+        }
         this._requiredVariableListName = name;
     }
 
@@ -92,10 +104,6 @@ public class CommandDefinition {
         return (this._requiredVariableListName);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -122,10 +130,6 @@ public class CommandDefinition {
         return (this._names);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -135,7 +139,7 @@ public class CommandDefinition {
     }
 
     protected boolean hasOptionalVariableLists() {
-        return (this._optionalVariableListName != null && this._optionalVariableListName.length() > 0);
+        return (this._optionalVariableListName != null && !this._optionalVariableListName.isEmpty());
     }
 
     protected boolean hasOptionalVariables() {
@@ -143,7 +147,7 @@ public class CommandDefinition {
     }
 
     protected boolean hasRequiredVariableLists() {
-        return (this._requiredVariableListName != null && this._requiredVariableListName.length() > 0);
+        return (this._requiredVariableListName != null && !this._requiredVariableListName.isEmpty());
     }
 
     protected boolean hasRequiredVariables() {
@@ -164,10 +168,6 @@ public class CommandDefinition {
         this._regexValue = regexValue;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return String.format(

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * This class is a command definition. It is created when the CmdLine.defineCommand() is called.
+ * This class is a command definition. It is created when {@link CmdLine#defineCommand(String)} is called.
  *
  * @author G Brown
  */

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinition.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * This class is a command definition. It is created when the CmdLine.defineCommand() is called.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class CommandDefinition {
     protected String _description;

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * (or {@code ?...} for optional list) - {@code :} : Regex validation - No prefix: Command name Splits on {@code =} and
  * {@code ,} delimiters, prioritizing equals over commas.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class CommandDefinitionTokenizer {
 

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
@@ -101,10 +101,25 @@ public class CommandDefinitionTokenizer {
             return new ArrayList<>();
         }
 
-        return Arrays.stream(args).flatMap(arg -> Arrays.stream(arg.split("="))) // Split on '=', flatten
-                .flatMap(eqPart -> Arrays.stream(eqPart.split(","))) // Split on ',', flatten
-                .filter(s -> !s.isEmpty()) // Ignore empty strings
-                .map(s -> createToken(s)) // Create tokens (lambda for explicit type inference)
-                .collect(Collectors.toList());
+        // A description is not split. Everything after '#' is prose, and prose
+        // contains commas and equals signs; splitting it produced spurious
+        // command tokens from the tail of a sentence.
+        final List<Token> tokens = new ArrayList<>();
+        for (final String arg : args) {
+            if (arg == null) {
+                continue;
+            }
+            final String trimmed = arg.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (trimmed.charAt(0) == '#') {
+                tokens.add(createToken(trimmed));
+                continue;
+            }
+            Arrays.stream(trimmed.split("=")).flatMap(eqPart -> Arrays.stream(eqPart.split(","))).map(String::trim)
+                    .filter(s -> !s.isEmpty()).map(CommandDefinitionTokenizer::createToken).forEach(tokens::add);
+        }
+        return tokens;
     }
 }

--- a/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandDefinitionTokenizer.java
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
  */
 public class CommandDefinitionTokenizer {
 
-    private static final int MAX_TOKEN_LENGTH = 1000; // Configurable max length for security
+    private static final int MAX_TOKEN_LENGTH = 256;
 
     /**
      * Protected constructor to prevent instantiation.
@@ -79,10 +79,10 @@ public class CommandDefinitionTokenizer {
         String value = isList ? inputString.substring(1, inputString.length() - 3) : inputString.substring(1);
 
         Token.Type type;
-        switch (required ? 1 : 0) {
-            case 1 -> type = isList ? Token.Type.REQUIRED_LIST_VALUE : Token.Type.REQUIRED_VALUE;
-            case 0 -> type = isList ? Token.Type.OPTIONAL_LIST_VALUE : Token.Type.OPTIONAL_VALUE;
-            default -> throw new IllegalStateException("Unexpected value");
+        if (required) {
+            type = isList ? Token.Type.REQUIRED_LIST_VALUE : Token.Type.REQUIRED_VALUE;
+        } else {
+            type = isList ? Token.Type.OPTIONAL_LIST_VALUE : Token.Type.OPTIONAL_VALUE;
         }
 
         return new Token(type, value);

--- a/src/main/java/com/gabstudios/cmdline/CommandListener.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandListener.java
@@ -22,14 +22,14 @@ package com.gabstudios.cmdline;
 /**
  * This interface handles the <code>Command</code> instances that are processed when the parse(...) method is called.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public interface CommandListener {
     /**
-     * Handles the parser callbacks when a Command is created.
+     * Called by the parser each time a {@link Command} is successfully created from the command line arguments.
      *
      * @param command
-     *            A Command instance.
+     *            The {@link Command} that was parsed. Contains the command name and any associated variable values.
      */
     public void handle(Command command);
 }

--- a/src/main/java/com/gabstudios/cmdline/CommandListener.java
+++ b/src/main/java/com/gabstudios/cmdline/CommandListener.java
@@ -24,6 +24,7 @@ package com.gabstudios.cmdline;
  *
  * @author G Brown
  */
+@FunctionalInterface
 public interface CommandListener {
     /**
      * Called by the parser each time a {@link Command} is successfully created from the command line arguments.
@@ -31,5 +32,5 @@ public interface CommandListener {
      * @param command
      *            The {@link Command} that was parsed. Contains the command name and any associated variable values.
      */
-    public void handle(Command command);
+    void handle(Command command);
 }

--- a/src/main/java/com/gabstudios/cmdline/DuplicateException.java
+++ b/src/main/java/com/gabstudios/cmdline/DuplicateException.java
@@ -37,7 +37,7 @@ public class DuplicateException extends RuntimeException {
      * @param message
      *            A <code>String</code> message.
      */
-    protected DuplicateException(final String message) {
+    public DuplicateException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/gabstudios/cmdline/DuplicateException.java
+++ b/src/main/java/com/gabstudios/cmdline/DuplicateException.java
@@ -22,7 +22,7 @@ package com.gabstudios.cmdline;
 /**
  * An exception that is used if a command or variable are already defined.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class DuplicateException extends RuntimeException {
 

--- a/src/main/java/com/gabstudios/cmdline/MatchException.java
+++ b/src/main/java/com/gabstudios/cmdline/MatchException.java
@@ -37,7 +37,7 @@ public class MatchException extends RuntimeException {
      * @param message
      *            A <code>String</code> message.
      */
-    protected MatchException(final String message) {
+    public MatchException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/gabstudios/cmdline/MatchException.java
+++ b/src/main/java/com/gabstudios/cmdline/MatchException.java
@@ -22,7 +22,7 @@ package com.gabstudios.cmdline;
 /**
  * An exception that is used if a match fails when the regex value has been defined.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class MatchException extends RuntimeException {
 

--- a/src/main/java/com/gabstudios/cmdline/MissingException.java
+++ b/src/main/java/com/gabstudios/cmdline/MissingException.java
@@ -37,7 +37,7 @@ public class MissingException extends RuntimeException {
      * @param message
      *            A <code>String</code> message.
      */
-    protected MissingException(final String message) {
+    public MissingException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/gabstudios/cmdline/MissingException.java
+++ b/src/main/java/com/gabstudios/cmdline/MissingException.java
@@ -22,7 +22,7 @@ package com.gabstudios.cmdline;
 /**
  * An exception that is used if a required token or arg is missing.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class MissingException extends RuntimeException {
 

--- a/src/main/java/com/gabstudios/cmdline/Token.java
+++ b/src/main/java/com/gabstudios/cmdline/Token.java
@@ -26,7 +26,7 @@ package com.gabstudios.cmdline;
  * will be used to validate the data within a VALUE REQUIRED_LIST_VALUE = A required variable that will have one to many
  * values. OPTIONAL_LIST_VALUE = An optional variable that will have zero to many values.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class Token {
 

--- a/src/main/java/com/gabstudios/cmdline/Token.java
+++ b/src/main/java/com/gabstudios/cmdline/Token.java
@@ -53,16 +53,6 @@ public class Token {
     /*
      * Constructor.
      */
-    protected Token(final Type type) {
-        assert (type != null) : TYPE_ERROR_STRING;
-
-        this._type = type;
-        this._value = null;
-    }
-
-    /*
-     * Constructor.
-     */
     protected Token(final Type type, final String value) {
         assert (type != null) : TYPE_ERROR_STRING;
         assert (value != null && value.length() > 0) : VALUE_ERROR_STRING;
@@ -71,10 +61,6 @@ public class Token {
         this._value = value;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -110,16 +96,12 @@ public class Token {
 
     /*
      * Get the value of the token.
-     * @return A String instance. May not be null or empty.
+     * @return A String instance. May be null if this token has no value.
      */
     protected String getValue() {
         return (this._value);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -129,10 +111,6 @@ public class Token {
         return result;
     }
 
-    /*
-     * (non-Javadoc)
-     * @see java.lang.Object#toString()
-     */
     @Override
     public String toString() {
         return String.format("Token [_value='%s', _type='%s']", this._value, this._type);

--- a/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
+++ b/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
@@ -25,7 +25,7 @@ import java.util.List;
 /**
  * An exception that is used if an action is not supported.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class UnsupportedException extends RuntimeException {
 

--- a/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
+++ b/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
@@ -50,12 +50,13 @@ public class UnsupportedException extends RuntimeException {
     }
 
     /**
-     * Constructor that takes a message.
+     * Constructor that takes a message and a list of suggested alternatives.
      *
      * @param message
      *            A <code>String</code> message.
      * @param suggestionList
-     *            A <code>List</code> of possible suggestions to return to the user if the command was misspelled
+     *            A <code>List</code> of command name suggestions to present to the user if the command was misspelled.
+     *            Must not be null.
      */
     public UnsupportedException(final String message, final List<String> suggestionList) {
         super(message);
@@ -65,7 +66,8 @@ public class UnsupportedException extends RuntimeException {
     /**
      * Gets a <code>List</code> of suggestion alternatives.
      *
-     * @return A <code>List</code> instance containing zero to many <code>String</code>instances.
+     * @return A <code>List</code> instance containing zero to many <code>String</code> instances. May be null if this
+     *         exception was created without a suggestion list.
      */
     public List<String> getSuggestionList() {
         return (this._suggestionList);

--- a/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
+++ b/src/main/java/com/gabstudios/cmdline/UnsupportedException.java
@@ -45,7 +45,7 @@ public class UnsupportedException extends RuntimeException {
      * @param message
      *            A <code>String</code> message.
      */
-    protected UnsupportedException(final String message) {
+    public UnsupportedException(final String message) {
         super(message);
     }
 

--- a/src/main/java/com/gabstudios/collection/LinkedHashMapTree.java
+++ b/src/main/java/com/gabstudios/collection/LinkedHashMapTree.java
@@ -285,8 +285,6 @@ public class LinkedHashMapTree<T> {
          * Sets the parent of the node. This is called when the addChild method is called.
          */
         private void setParent(final Node<T> parent) {
-            assert (parent != null) : "The parameter 'parent' should not be null.";
-            assert (parent.getData() != null) : "The parameter parent's data should not be null.";
             if (this._parent != null) {
                 this._parent.removeChild(this._data);
             }

--- a/src/main/java/com/gabstudios/collection/LinkedHashMapTree.java
+++ b/src/main/java/com/gabstudios/collection/LinkedHashMapTree.java
@@ -29,7 +29,7 @@ import java.util.List;
  * Duplicate siblings with the same value are not allowed. The order of when a child is added is maintained. A tree may
  * hold onto multiple nodes with the same data. A Node uses a hashmap to hold its children so the search is O(1).
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  *
  * @param <T>
  *            This defines the class type of the data.
@@ -39,7 +39,7 @@ public class LinkedHashMapTree<T> {
     /**
      * The node within a Tree.
      *
-     * @author Gregory Brown (sysdevone)
+     * @author G Brown
      *
      * @param <T>
      *            This defines the class type of the data.

--- a/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
+++ b/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
@@ -173,7 +173,7 @@ public class LinkedHashMapTrie extends LinkedHashMapTree<Character> implements T
         // hello
         // Tests to see if the character exists in the tree.
         // -------------------
-        final LinkedList<String> data = new LinkedList<String>();
+        final LinkedList<String> data = new LinkedList<>();
 
         final StringBuilder prefixWord = new StringBuilder();
         final int count = prefix.length();
@@ -219,10 +219,6 @@ public class LinkedHashMapTrie extends LinkedHashMapTree<Character> implements T
         return (data);
     }
 
-    /*
-     * (non-Javadoc)
-     * @see org.gabsocial.collection.Trie#contains(java.lang.String)
-     */
     @Override
     public boolean contains(String word) {
         if (word == null || word.isEmpty())

--- a/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
+++ b/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
@@ -19,9 +19,10 @@
 
 package com.gabstudios.collection;
 
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Stack;
 
 /**
  * An implementation of a Trie. Create a dictionary of words by using the add(String word ) method. This can be used to
@@ -191,21 +192,17 @@ public class LinkedHashMapTrie extends LinkedHashMapTree<Character> implements T
             }
         }
 
-        final Stack<TrieNode> stack = new Stack<>();
+        final Deque<TrieNode> stack = new ArrayDeque<>();
         stack.push(node);
 
-        final Stack<String> prefixStack = new Stack<>();
+        final Deque<String> prefixStack = new ArrayDeque<>();
         prefixStack.push(prefixWord.toString());
 
         while (!stack.isEmpty()) {
             final TrieNode stackNode = stack.pop();
-            String rootPrefix = null;
-            if (!stackNode.isEmpty()) {
-                rootPrefix = prefixStack.pop();
-                if (stackNode.isWord()) {
-                    data.add(rootPrefix);
-                }
-
+            final String rootPrefix = prefixStack.pop();
+            if (stackNode.isWord()) {
+                data.add(rootPrefix);
             }
 
             final List<Node<Character>> children = stackNode.getChildren();

--- a/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
+++ b/src/main/java/com/gabstudios/collection/LinkedHashMapTrie.java
@@ -27,14 +27,14 @@ import java.util.Stack;
  * An implementation of a Trie. Create a dictionary of words by using the add(String word ) method. This can be used to
  * get words that are similar prefix by using the getWords( String prefix ) method.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public class LinkedHashMapTrie extends LinkedHashMapTree<Character> implements Trie {
 
     /**
      * The node within a Tree that holds a <code>Character</code>.
      *
-     * @author Gregory Brown (sysdevone)
+     * @author G Brown
      */
     public static class TrieNode extends Node<Character> {
         /*

--- a/src/main/java/com/gabstudios/collection/Trie.java
+++ b/src/main/java/com/gabstudios/collection/Trie.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * A Trie interface.
  *
- * @author Gregory Brown (sysdevone)
+ * @author G Brown
  */
 public abstract interface Trie {
     /**

--- a/src/test/java/com/gabstudios/cmdline/CmdLineInstanceTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineInstanceTest.java
@@ -1,0 +1,198 @@
+/*****************************************************************************************
+ *
+ * Copyright 2016-2025 Gregory Brown. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ *****************************************************************************************
+ */
+
+package com.gabstudios.cmdline;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the behaviours introduced when {@link CmdLine} became an instance class.
+ * <p>
+ * Each test here pins a decision rather than an implementation detail: isolation between parsers, descriptions being
+ * prose, variable names being scoped to their command, an empty argument array being ordinary, and a listener applying
+ * only to the parse it was passed to.
+ *
+ * @author G Brown
+ */
+public class CmdLineInstanceTest {
+
+    /**
+     * Two parsers share nothing. This is the point of the change: isolation no longer depends on remembering to clear a
+     * global before the next use.
+     */
+    @Test
+    public void testInstancesAreIsolated() {
+        final CmdLine first = new CmdLine();
+        final CmdLine second = new CmdLine();
+
+        first.defineCommand("-a, --alpha, #Only known to the first parser");
+
+        final List<Command> parsedByFirst = first.parse(new String[] { "-a" });
+        Assertions.assertEquals(1, parsedByFirst.size());
+
+        try {
+            second.parse(new String[] { "-a" });
+            Assertions.fail("the second parser should not know a command defined on the first");
+        } catch (final UnsupportedException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    /** State set on one parser does not leak to another. */
+    @Test
+    public void testInstanceStateIsNotShared() {
+        final CmdLine first = new CmdLine();
+        final CmdLine second = new CmdLine();
+
+        first.setApplicationName("first").setVersion("1.0");
+
+        Assertions.assertEquals("first", first.getApplicationName());
+        Assertions.assertNull(second.getApplicationName());
+        Assertions.assertNull(second.getVersion());
+    }
+
+    /** Chaining on an instance is the supported form and returns the same object. */
+    @Test
+    public void testChainingReturnsTheSameInstance() {
+        final CmdLine cmdLine = new CmdLine();
+        final CmdLine returned = cmdLine.defineCommand("-a, --alpha, #Alpha").defineCommand("-b, --beta, #Beta")
+                .setApplicationName("test");
+
+        Assertions.assertSame(cmdLine, returned);
+    }
+
+    /**
+     * A description is prose and runs to the end of the definition.
+     * <p>
+     * It used to be split on commas, so the tail of a sentence became a second command name — reported as an error
+     * about spaces that mentioned neither the comma nor the description.
+     */
+    @Test
+    public void testDescriptionMayContainCommas() {
+        final CmdLine cmdLine = new CmdLine();
+        cmdLine.defineCommand("-i, --imports, #List imports, newest first");
+
+        final List<Command> commands = cmdLine.parse(new String[] { "--imports" });
+        Assertions.assertEquals(1, commands.size());
+        Assertions.assertEquals("--imports", commands.get(0).getName());
+    }
+
+    /** An equals sign in a description is prose too. */
+    @Test
+    public void testDescriptionMayContainEquals() {
+        final CmdLine cmdLine = new CmdLine();
+        cmdLine.defineCommand("-p, --property, !pair, #Set a property as key=value");
+
+        final List<Command> commands = cmdLine.parse(new String[] { "--property", "a" });
+        Assertions.assertEquals(1, commands.size());
+        Assertions.assertEquals("a", commands.get(0).getValues("pair").get(0));
+    }
+
+    /**
+     * Variable names are scoped to the command that declares them.
+     * <p>
+     * Two options both taking a {@code !file} is ordinary — a value name describes that option's argument, not a
+     * program-wide identifier.
+     */
+    @Test
+    public void testVariableNamesAreScopedToTheirCommand() {
+        final CmdLine cmdLine = new CmdLine();
+        cmdLine.defineCommand("-u, --upload, !file, #Upload a file");
+        cmdLine.defineCommand("-c, --cacert, !file, #Certificate to trust");
+
+        final List<Command> commands = cmdLine.parse(new String[] { "--upload", "scan.sarif", "--cacert", "ca.pem" });
+
+        Assertions.assertEquals(2, commands.size());
+        Assertions.assertEquals("scan.sarif", commands.get(0).getValues("file").get(0));
+        Assertions.assertEquals("ca.pem", commands.get(1).getValues("file").get(0));
+    }
+
+    /** Declaring the same variable twice in ONE command is still a duplicate. */
+    @Test
+    public void testDuplicateVariableWithinOneCommandIsStillRefused() {
+        final CmdLine cmdLine = new CmdLine();
+        try {
+            cmdLine.defineCommand("-u, --upload, !file, !file, #Upload a file");
+            Assertions.fail("one command may not declare the same variable twice");
+        } catch (final DuplicateException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    /** No arguments is the most common invocation of a tool, and yields no commands. */
+    @Test
+    public void testEmptyArgumentsYieldNoCommands() {
+        final CmdLine cmdLine = new CmdLine();
+        cmdLine.defineCommand("-a, --alpha, #Alpha");
+
+        final List<Command> commands = cmdLine.parse(new String[0]);
+        Assertions.assertNotNull(commands);
+        Assertions.assertTrue(commands.isEmpty());
+    }
+
+    /**
+     * A listener applies to the parse it was given and no other.
+     * <p>
+     * It used to be stored globally, so a later plain parse still notified a listener the caller had passed once — hard
+     * to trace, because nothing at the second call site mentions it.
+     */
+    @Test
+    public void testListenerDoesNotPersistBeyondItsParse() {
+        final CmdLine cmdLine = new CmdLine();
+        cmdLine.defineCommand("-a, --alpha, #Alpha");
+
+        final int[] handled = new int[1];
+        final CommandListener listener = command -> handled[0]++;
+
+        cmdLine.parse(new String[] { "-a" }, listener);
+        Assertions.assertEquals(1, handled[0]);
+
+        cmdLine.parse(new String[] { "-a" });
+        Assertions.assertEquals(1, handled[0], "the listener should not have been notified again");
+    }
+
+    /** A definition made only of variables names no command, and is refused. */
+    @Test
+    public void testDefinitionMustNameACommand() {
+        final CmdLine cmdLine = new CmdLine();
+        try {
+            cmdLine.defineCommand("!justAVariable");
+            Assertions.fail("a definition with no command name should be refused");
+        } catch (final MissingException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    /**
+     * A definition of nothing but whitespace is refused.
+     * <p>
+     * It used to survive as a command name containing spaces and be refused for that reason; tokens are now trimmed, so
+     * the emptiness is reported for what it is.
+     */
+    @Test
+    public void testWhitespaceOnlyDefinitionIsRefused() {
+        final CmdLine cmdLine = new CmdLine();
+        try {
+            cmdLine.defineCommand("    ");
+            Assertions.fail("a whitespace-only definition should be refused");
+        } catch (final UnsupportedException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+}

--- a/src/test/java/com/gabstudios/cmdline/CmdLineNegativeTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineNegativeTest.java
@@ -19,6 +19,8 @@
 
 package com.gabstudios.cmdline;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,13 +31,16 @@ import org.junit.jupiter.api.Test;
  */
 public class CmdLineNegativeTest {
 
+    private CmdLine cmdLine;
+
     @BeforeEach
     public void setUp() {
+        this.cmdLine = new CmdLine();
     }
 
     @AfterEach
     public void tearDown() {
-        CmdLine.clear();
+        this.cmdLine.clear();
     }
 
     @Test
@@ -43,7 +48,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("!fileName, ?fileName1, :file\\d.txt, #Load files into the system");
+            this.cmdLine.defineCommand("!fileName, ?fileName1, :file\\d.txt, #Load files into the system");
 
             Assertions.fail();
         } catch (MissingException e) {
@@ -56,7 +61,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, !fileName, ?fileName, :file\\d.txt, #Load files into the system");
+            this.cmdLine.defineCommand("file, !fileName, ?fileName, :file\\d.txt, #Load files into the system");
 
             Assertions.fail();
         } catch (DuplicateException e) {
@@ -69,7 +74,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, file, !fileName, :file\\d.txt, #Load files into the system");
+            this.cmdLine.defineCommand("file, file, !fileName, :file\\d.txt, #Load files into the system");
 
             Assertions.fail();
         } catch (DuplicateException e) {
@@ -82,7 +87,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, !fileName, :file\\d.txt, :file\\d.txt, #Load files into the system");
+            this.cmdLine.defineCommand("file, !fileName, :file\\d.txt, :file\\d.txt, #Load files into the system");
 
             Assertions.fail();
         } catch (DuplicateException e) {
@@ -95,8 +100,11 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand(
-                    "file, !fileName, :file\\d.txt, #Load files into the system, #Load files into the system");
+            // Passed as separate tokens: within a single comma-delimited string
+            // the first '#' now begins a description that runs to the end, so a
+            // later '#' is part of that prose rather than a second description.
+            this.cmdLine.defineCommand("file", "!fileName", ":file\\d.txt", "#Load files into the system",
+                    "#Load files into the system");
 
             Assertions.fail();
         } catch (DuplicateException e) {
@@ -109,7 +117,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file !fileName :file\\d.txt #Load files into the system");
+            this.cmdLine.defineCommand("file !fileName :file\\d.txt #Load files into the system");
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -122,7 +130,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, !fileNames..., ?fileNames...");
+            this.cmdLine.defineCommand("file, !fileNames..., ?fileNames...");
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -136,7 +144,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, ?fileNames..., !fileNames2...");
+            this.cmdLine.defineCommand("file, ?fileNames..., !fileNames2...");
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -147,7 +155,7 @@ public class CmdLineNegativeTest {
     @Test
     public void testDefineCommand8() {
 
-        CmdLine.defineCommand("file, !file1, !file2");
+        this.cmdLine.defineCommand("file, !file1, !file2");
 
         final String[] args = new String[3];
         args[0] = "file";
@@ -155,7 +163,7 @@ public class CmdLineNegativeTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.fail();
         } catch (MissingException e) {
@@ -166,7 +174,7 @@ public class CmdLineNegativeTest {
     @Test
     public void testDefineCommand9() {
 
-        CmdLine.defineCommand("file, !file, !files...");
+        this.cmdLine.defineCommand("file, !file, !files...");
 
         final String[] args = new String[3];
         args[0] = "file";
@@ -174,7 +182,7 @@ public class CmdLineNegativeTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.fail();
         } catch (MissingException e) {
@@ -185,7 +193,7 @@ public class CmdLineNegativeTest {
     @Test
     public void testDefineCommand10() {
 
-        CmdLine.defineCommand("file, !file");
+        this.cmdLine.defineCommand("file, !file");
 
         final String[] args = new String[3];
         args[0] = "install";
@@ -193,7 +201,7 @@ public class CmdLineNegativeTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -206,7 +214,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("file, ?fileName1, !fileNames2");
+            this.cmdLine.defineCommand("file, ?fileName1, !fileNames2");
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -219,7 +227,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("");
+            this.cmdLine.defineCommand("");
 
             Assertions.fail();
         } catch (IllegalArgumentException e) {
@@ -232,7 +240,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand();
+            this.cmdLine.defineCommand();
 
             Assertions.fail();
         } catch (IllegalArgumentException e) {
@@ -245,7 +253,7 @@ public class CmdLineNegativeTest {
 
         try {
 
-            CmdLine.defineCommand("    ");
+            this.cmdLine.defineCommand("    ");
 
             Assertions.fail();
         } catch (UnsupportedException e) {
@@ -257,29 +265,29 @@ public class CmdLineNegativeTest {
     public void testDefineCommandNullStringThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.defineCommand((String) null);
+            this.cmdLine.defineCommand((String) null);
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
         }
+    }
+
+    @Test
+    public void testParseEmptyArgsReturnsNoCommands() {
+
+        // Running a tool with no arguments is its most common invocation, so it
+        // yields no commands rather than an exception. An application that wants
+        // to show help then does not have to special-case it before calling.
+        final List<Command> commands = this.cmdLine.parse(new String[0]);
+        Assertions.assertNotNull(commands);
+        Assertions.assertTrue(commands.isEmpty());
     }
 
     @Test
     public void testParseNullArgsThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.parse(null);
-            Assertions.fail();
-        } catch (IllegalArgumentException e) {
-            Assertions.assertTrue(true);
-        }
-    }
-
-    @Test
-    public void testParseEmptyArgsThrowsIllegalArgumentException() {
-
-        try {
-            CmdLine.parse(new String[0]);
+            this.cmdLine.parse(null);
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
@@ -290,7 +298,7 @@ public class CmdLineNegativeTest {
     public void testSetApplicationNameNullThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.setApplicationName(null);
+            this.cmdLine.setApplicationName(null);
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
@@ -301,7 +309,7 @@ public class CmdLineNegativeTest {
     public void testSetApplicationNameEmptyThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.setApplicationName("");
+            this.cmdLine.setApplicationName("");
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
@@ -312,7 +320,7 @@ public class CmdLineNegativeTest {
     public void testSetVersionNullThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.setVersion(null);
+            this.cmdLine.setVersion(null);
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
@@ -323,7 +331,7 @@ public class CmdLineNegativeTest {
     public void testSetVersionEmptyThrowsIllegalArgumentException() {
 
         try {
-            CmdLine.setVersion("");
+            this.cmdLine.setVersion("");
             Assertions.fail();
         } catch (IllegalArgumentException e) {
             Assertions.assertTrue(true);
@@ -333,11 +341,11 @@ public class CmdLineNegativeTest {
     @Test
     public void testParseValueDoesNotMatchRegexThrowsMatchException() {
 
-        CmdLine.defineCommand("file, !fileName, :file\\d.txt");
+        this.cmdLine.defineCommand("file, !fileName, :file\\d.txt");
 
         final String[] args = { "file=badvalue.txt" };
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
             Assertions.fail();
         } catch (MatchException e) {
             Assertions.assertTrue(true);
@@ -349,7 +357,7 @@ public class CmdLineNegativeTest {
 
         final String[] args = { "-Dcom.example.debug=true" };
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
             Assertions.fail();
         } catch (UnsupportedException e) {
             Assertions.assertTrue(true);
@@ -359,11 +367,11 @@ public class CmdLineNegativeTest {
     @Test
     public void testSystemPropertyBlockedJvmPrefixThrowsUnsupportedException() {
 
-        CmdLine.setSystemPropertiesEnabled(true);
+        this.cmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = { "-Djava.home=/usr/lib/jvm" };
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
             Assertions.fail();
         } catch (UnsupportedException e) {
             Assertions.assertTrue(true);

--- a/src/test/java/com/gabstudios/cmdline/CmdLineNegativeTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineNegativeTest.java
@@ -253,4 +253,127 @@ public class CmdLineNegativeTest {
         }
     }
 
+    @Test
+    public void testDefineCommandNullStringThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.defineCommand((String) null);
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testParseNullArgsThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.parse(null);
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testParseEmptyArgsThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.parse(new String[0]);
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetApplicationNameNullThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.setApplicationName(null);
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetApplicationNameEmptyThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.setApplicationName("");
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetVersionNullThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.setVersion(null);
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetVersionEmptyThrowsIllegalArgumentException() {
+
+        try {
+            CmdLine.setVersion("");
+            Assertions.fail();
+        } catch (IllegalArgumentException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testParseValueDoesNotMatchRegexThrowsMatchException() {
+
+        CmdLine.defineCommand("file, !fileName, :file\\d.txt");
+
+        final String[] args = { "file=badvalue.txt" };
+        try {
+            CmdLine.parse(args);
+            Assertions.fail();
+        } catch (MatchException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSystemPropertyDisabledByDefault() {
+
+        final String[] args = { "-Dcom.example.debug=true" };
+        try {
+            CmdLine.parse(args);
+            Assertions.fail();
+        } catch (UnsupportedException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSystemPropertyBlockedJvmPrefixThrowsUnsupportedException() {
+
+        CmdLine.setSystemPropertiesEnabled(true);
+
+        final String[] args = { "-Djava.home=/usr/lib/jvm" };
+        try {
+            CmdLine.parse(args);
+            Assertions.fail();
+        } catch (UnsupportedException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testUnsupportedExceptionGetSuggestionListReturnsNullWithNoSuggestions() {
+        final UnsupportedException ex = new UnsupportedException("error");
+        Assertions.assertNull(ex.getSuggestionList());
+    }
+
 }

--- a/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
@@ -1003,6 +1003,20 @@ public class CmdLineTest {
     }
 
     @Test
+    public void testClearResetsSystemPropertiesEnabled() {
+        CmdLine.setSystemPropertiesEnabled(true);
+        CmdLine.clear(); // should reset the flag to false
+
+        final String[] args = { "-Dcom.example.debug=true" };
+        try {
+            CmdLine.parse(args);
+            Assertions.fail();
+        } catch (final UnsupportedException e) {
+            Assertions.assertTrue(true);
+        }
+    }
+
+    @Test
     public void testTokenizer3() {
         // -file=file1,txt, file2.txt -Dorg.gabsocial.cmdline.debug=true
         final String[] inputTokens = { "-file", "file1.txt", "file2.txt", "-Dorg.gabsocial.cmdline.debug=true" };

--- a/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
@@ -1003,6 +1003,26 @@ public class CmdLineTest {
     }
 
     @Test
+    public void testParseDoesNotAccumulateCommandsAcrossCalls() {
+        CmdLine.defineCommand("-f, --file, !fileName");
+        CmdLine.defineCommand("-l, --list");
+
+        final String[] firstArgs = { "-f", "=", "file1.txt" };
+        final String[] secondArgs = { "--list" };
+
+        try {
+            final List<Command> firstResult = CmdLine.parse(firstArgs);
+            Assertions.assertEquals(1, firstResult.size());
+
+            final List<Command> secondResult = CmdLine.parse(secondArgs);
+            Assertions.assertEquals(1, secondResult.size());
+            Assertions.assertEquals("--list", secondResult.get(0).getName());
+        } catch (final Exception e) {
+            Assertions.fail(e.toString());
+        }
+    }
+
+    @Test
     public void testClearResetsSystemPropertiesEnabled() {
         CmdLine.setSystemPropertiesEnabled(true);
         CmdLine.clear(); // should reset the flag to false

--- a/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
@@ -32,6 +32,9 @@ import org.junit.jupiter.api.Test;
  * @author Gregory Brown (sysdevone)
  */
 public class CmdLineTest {
+
+    private CmdLine cmdLine;
+
     private class CmdLineListener implements CommandListener {
 
         private final Map<String, Command> _commandMap = new HashMap<String, Command>();
@@ -54,26 +57,27 @@ public class CmdLineTest {
 
     @BeforeEach
     public void setUp() {
+        this.cmdLine = new CmdLine();
     }
 
     @AfterEach
     public void tearDown() {
-        CmdLine.clear();
+        this.cmdLine.clear();
     }
 
     @Test
     public void testDefineCommand() {
 
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("file , !fileName1,:file\\d.txt,       #Load files into the system");
+        this.cmdLine.defineCommand("file , !fileName1,:file\\d.txt,       #Load files into the system");
 
         final String[] args = new String[1];
         args[0] = "file=file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -99,15 +103,15 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("file, !fileName1, :file\\d.txt, #Load a files into the system");
+        this.cmdLine.defineCommand("file, !fileName1, :file\\d.txt, #Load a files into the system");
 
         final String[] args = new String[1];
         args[0] = "file = file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -134,16 +138,16 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1a() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand(
+        this.cmdLine.defineCommand(
                 "-f, --file, !fileName1, ?fileName2, ?fileName3, :file\\d.txt, #Load a files into the system");
 
         final String[] args = new String[1];
         args[0] = "-f=file1.txt, file2.txt, file3.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -187,9 +191,9 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1b() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand(
+        this.cmdLine.defineCommand(
                 "-f, --file, !fileName1, ?fileName2, ?fileName3, :file\\d.txt, #Load a files into the system");
 
         final String[] args = new String[3];
@@ -198,7 +202,7 @@ public class CmdLineTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -224,9 +228,9 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1c() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("-f, --file, !fileName1, ?fileName2, ?fileName3, #Load a files into the system");
+        this.cmdLine.defineCommand("-f, --file, !fileName1, ?fileName2, ?fileName3, #Load a files into the system");
 
         final String[] args = new String[3];
         args[0] = "-f";
@@ -234,7 +238,7 @@ public class CmdLineTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -260,9 +264,9 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1d() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("-f, --file, !fileName1, ?fileNames..., #Load a files into the system");
+        this.cmdLine.defineCommand("-f, --file, !fileName1, ?fileNames..., #Load a files into the system");
 
         final String[] args = new String[7];
         args[0] = "-f";
@@ -274,7 +278,7 @@ public class CmdLineTest {
         args[6] = "file3.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -314,9 +318,12 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1e() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("-f, --file, !fileName1, ?fileNames..., #Load a files into the system, file");
+        // "file" is a command name and now precedes the description. It used to
+        // trail it and be recovered only because the description was split on
+        // commas; a description is prose and is no longer split.
+        this.cmdLine.defineCommand("-f, --file, file, !fileName1, ?fileNames..., #Load a files into the system");
 
         final String[] args = new String[7];
         args[0] = "file";
@@ -328,7 +335,7 @@ public class CmdLineTest {
         args[6] = "file3.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -368,9 +375,9 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1f() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("file, !file");
+        this.cmdLine.defineCommand("file, !file");
 
         final String[] args = new String[3];
         args[0] = "file";
@@ -378,7 +385,7 @@ public class CmdLineTest {
         args[2] = "file1.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -404,9 +411,9 @@ public class CmdLineTest {
     @Test
     public void testDefineCommand1g() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("file, !file, !files...");
+        this.cmdLine.defineCommand("file, !file, !files...");
 
         final String[] args = new String[5];
         args[0] = "file";
@@ -416,7 +423,7 @@ public class CmdLineTest {
         args[4] = "file2.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -443,7 +450,7 @@ public class CmdLineTest {
     public void testParseWithListener() {
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.defineCommand("file, !file, !files...");
+        this.cmdLine.defineCommand("file, !file, !files...");
 
         final String[] args = new String[5];
         args[0] = "file";
@@ -453,7 +460,7 @@ public class CmdLineTest {
         args[4] = "file2.txt";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -488,7 +495,7 @@ public class CmdLineTest {
         args[4] = "file2.txt";
 
         try {
-            CmdLine.defineCommand("file, !file, !files...").parse(args, listener);
+            this.cmdLine.defineCommand("file, !file, !files...").parse(args, listener);
 
             Assertions.assertTrue(listener.getCount() == 1);
 
@@ -514,12 +521,12 @@ public class CmdLineTest {
     @Test
     public void testDefineMultipleCommand1() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.setVersion("1.1.0");
-        CmdLine.defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system");
-        CmdLine.defineCommand("-l", "--list", "#List the files loaded into the system");
-        CmdLine.defineCommand("-q", "--quit", "#Quit the application");
+        this.cmdLine.setVersion("1.1.0");
+        this.cmdLine.defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system");
+        this.cmdLine.defineCommand("-l", "--list", "#List the files loaded into the system");
+        this.cmdLine.defineCommand("-q", "--quit", "#Quit the application");
 
         final String[] args = new String[4];
         args[0] = "-f";
@@ -528,7 +535,7 @@ public class CmdLineTest {
         args[3] = "--list";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 2);
 
@@ -558,7 +565,7 @@ public class CmdLineTest {
     @Test
     public void testDefineMultipleCommand2() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -571,7 +578,7 @@ public class CmdLineTest {
         args[4] = "--list";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.assertTrue(listener.getCount() == 3);
 
@@ -613,7 +620,7 @@ public class CmdLineTest {
 
     @Test
     public void testDefineMultipleCommandWithDefaultListener() {
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -626,7 +633,7 @@ public class CmdLineTest {
         args[4] = "--list";
 
         try {
-            List<Command> commands = CmdLine.parse(args);
+            List<Command> commands = this.cmdLine.parse(args);
             Assertions.assertTrue(commands.size() == 3);
 
             for (Command command : commands) {
@@ -672,7 +679,7 @@ public class CmdLineTest {
     @Test
     public void testDefineMultipleCommandWithDefaultListenerAndSecondListener() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -685,7 +692,7 @@ public class CmdLineTest {
         args[4] = "--list";
 
         try {
-            List<Command> commands = CmdLine.parse(args, listener);
+            List<Command> commands = this.cmdLine.parse(args, listener);
             Assertions.assertTrue(commands.size() == 3);
 
             for (Command command : commands) {
@@ -764,16 +771,16 @@ public class CmdLineTest {
     @Test
     public void testSystemPropertyCommand1() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.setVersion("1.1.0");
-        CmdLine.setSystemPropertiesEnabled(true);
+        this.cmdLine.setVersion("1.1.0");
+        this.cmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[1];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             final Command command = listener.getCommand("-Dcom.gabsocial.cmdline.debug");
 
@@ -799,10 +806,10 @@ public class CmdLineTest {
     @Test
     public void testSystemPropertyCommand2() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.setVersion("1.1.0");
-        CmdLine.setSystemPropertiesEnabled(true);
+        this.cmdLine.setVersion("1.1.0");
+        this.cmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[4];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -811,7 +818,7 @@ public class CmdLineTest {
         args[3] = "-Dcom.gabsocial.cmdline.load=true";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 4);
 
@@ -838,12 +845,12 @@ public class CmdLineTest {
     @Test
     public void testSystemPropertyCommand3() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setCommandListener(listener);
+        this.cmdLine.setCommandListener(listener);
 
-        CmdLine.defineCommand("file, !file, !files..., :file\\d.txt");
+        this.cmdLine.defineCommand("file, !file, !files..., :file\\d.txt");
 
-        CmdLine.setVersion("1.1.0");
-        CmdLine.setSystemPropertiesEnabled(true);
+        this.cmdLine.setVersion("1.1.0");
+        this.cmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[4];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -852,7 +859,7 @@ public class CmdLineTest {
         args[3] = "file2.txt";
 
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
 
             Assertions.assertTrue(listener.getCount() == 2);
 
@@ -903,8 +910,8 @@ public class CmdLineTest {
     public void testSystemPropertyCommand4() {
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.defineCommand("file, !file, !files..., :file\\d.txt").setApplicationName("myApp").setVersion("1.1.0")
-                .setSystemPropertiesEnabled(true);
+        this.cmdLine.defineCommand("file, !file, !files..., :file\\d.txt").setApplicationName("myApp")
+                .setVersion("1.1.0").setSystemPropertiesEnabled(true);
 
         final String[] args = new String[5];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -914,7 +921,7 @@ public class CmdLineTest {
         args[4] = "-Dcom.gabsocial.cmdline.load=true";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.assertTrue(listener.getCount() == 3);
 
@@ -1004,17 +1011,17 @@ public class CmdLineTest {
 
     @Test
     public void testParseDoesNotAccumulateCommandsAcrossCalls() {
-        CmdLine.defineCommand("-f, --file, !fileName");
-        CmdLine.defineCommand("-l, --list");
+        this.cmdLine.defineCommand("-f, --file, !fileName");
+        this.cmdLine.defineCommand("-l, --list");
 
         final String[] firstArgs = { "-f", "=", "file1.txt" };
         final String[] secondArgs = { "--list" };
 
         try {
-            final List<Command> firstResult = CmdLine.parse(firstArgs);
+            final List<Command> firstResult = this.cmdLine.parse(firstArgs);
             Assertions.assertEquals(1, firstResult.size());
 
-            final List<Command> secondResult = CmdLine.parse(secondArgs);
+            final List<Command> secondResult = this.cmdLine.parse(secondArgs);
             Assertions.assertEquals(1, secondResult.size());
             Assertions.assertEquals("--list", secondResult.get(0).getName());
         } catch (final Exception e) {
@@ -1024,12 +1031,12 @@ public class CmdLineTest {
 
     @Test
     public void testClearResetsSystemPropertiesEnabled() {
-        CmdLine.setSystemPropertiesEnabled(true);
-        CmdLine.clear(); // should reset the flag to false
+        this.cmdLine.setSystemPropertiesEnabled(true);
+        this.cmdLine.clear(); // should reset the flag to false
 
         final String[] args = { "-Dcom.example.debug=true" };
         try {
-            CmdLine.parse(args);
+            this.cmdLine.parse(args);
             Assertions.fail();
         } catch (final UnsupportedException e) {
             Assertions.assertTrue(true);

--- a/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdLineTest.java
@@ -558,7 +558,7 @@ public class CmdLineTest {
     @Test
     public void testDefineMultipleCommand2() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0")
+        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -613,7 +613,7 @@ public class CmdLineTest {
 
     @Test
     public void testDefineMultipleCommandWithDefaultListener() {
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0")
+        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -672,7 +672,7 @@ public class CmdLineTest {
     @Test
     public void testDefineMultipleCommandWithDefaultListenerAndSecondListener() {
         final CmdLineListener listener = new CmdLineListener();
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0")
+        CmdLine.setApplicationName("myApp").setVersion("1.1.0").setSystemPropertiesEnabled(true)
                 .defineCommand("-f", "--file", "!fileNames...", ":file\\d.txt", "#Load files into the system")
                 .defineCommand("-l", "--list", "#List the files loaded into the system")
                 .defineCommand("-q", "--quit", "#Quit the application");
@@ -767,6 +767,7 @@ public class CmdLineTest {
         CmdLine.setCommandListener(listener);
 
         CmdLine.setVersion("1.1.0");
+        CmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[1];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -801,6 +802,7 @@ public class CmdLineTest {
         CmdLine.setCommandListener(listener);
 
         CmdLine.setVersion("1.1.0");
+        CmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[4];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -841,6 +843,7 @@ public class CmdLineTest {
         CmdLine.defineCommand("file, !file, !files..., :file\\d.txt");
 
         CmdLine.setVersion("1.1.0");
+        CmdLine.setSystemPropertiesEnabled(true);
 
         final String[] args = new String[4];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";
@@ -900,7 +903,8 @@ public class CmdLineTest {
     public void testSystemPropertyCommand4() {
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.defineCommand("file, !file, !files..., :file\\d.txt").setApplicationName("myApp").setVersion("1.1.0");
+        CmdLine.defineCommand("file, !file, !files..., :file\\d.txt").setApplicationName("myApp").setVersion("1.1.0")
+                .setSystemPropertiesEnabled(true);
 
         final String[] args = new String[5];
         args[0] = "-Dcom.gabsocial.cmdline.debug=true";

--- a/src/test/java/com/gabstudios/cmdline/CmdlineNegativeWordSuggestionTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CmdlineNegativeWordSuggestionTest.java
@@ -28,6 +28,9 @@ import org.junit.jupiter.api.*;
  * @author Gregory Brown (sysdevone)
  */
 public class CmdlineNegativeWordSuggestionTest {
+
+    private CmdLine cmdLine;
+
     private class CmdLineListener implements CommandListener {
 
         private final Map<String, Command> _commandMap = new HashMap<String, Command>();
@@ -50,11 +53,12 @@ public class CmdlineNegativeWordSuggestionTest {
 
     @BeforeEach
     public void setUp() {
+        this.cmdLine = new CmdLine();
     }
 
     @AfterEach
     public void tearDown() {
-        CmdLine.clear();
+        this.cmdLine.clear();
     }
 
     @Test
@@ -62,15 +66,15 @@ public class CmdlineNegativeWordSuggestionTest {
 
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").defineCommand("file, !file, !files..., :file\\d.txt")
-                .defineCommand("help").defineCommand("quit").defineCommand("install, !installOption")
-                .defineCommand("info");
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0")
+                .defineCommand("file, !file, !files..., :file\\d.txt").defineCommand("help").defineCommand("quit")
+                .defineCommand("install, !installOption").defineCommand("info");
 
         final String[] args = new String[1];
         args[0] = "inztolll";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.fail();
         } catch (final UnsupportedException e) {
@@ -88,15 +92,15 @@ public class CmdlineNegativeWordSuggestionTest {
 
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").defineCommand("file, !file, !files..., :file\\d.txt")
-                .defineCommand("help").defineCommand("quit").defineCommand("install, !installOption")
-                .defineCommand("info");
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0")
+                .defineCommand("file, !file, !files..., :file\\d.txt").defineCommand("help").defineCommand("quit")
+                .defineCommand("install, !installOption").defineCommand("info");
 
         final String[] args = new String[1];
         args[0] = "instolll";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.fail();
         } catch (final UnsupportedException e) {
@@ -113,15 +117,15 @@ public class CmdlineNegativeWordSuggestionTest {
 
         final CmdLineListener listener = new CmdLineListener();
 
-        CmdLine.setApplicationName("myApp").setVersion("1.1.0").defineCommand("file, !file, !files..., :file\\d.txt")
-                .defineCommand("help").defineCommand("quit").defineCommand("install, !installOption")
-                .defineCommand("info");
+        this.cmdLine.setApplicationName("myApp").setVersion("1.1.0")
+                .defineCommand("file, !file, !files..., :file\\d.txt").defineCommand("help").defineCommand("quit")
+                .defineCommand("install, !installOption").defineCommand("info");
 
         final String[] args = new String[1];
         args[0] = "znstolll";
 
         try {
-            CmdLine.parse(args, listener);
+            this.cmdLine.parse(args, listener);
 
             Assertions.fail();
         } catch (final UnsupportedException e) {

--- a/src/test/java/com/gabstudios/cmdline/CommandDefinitionTokenizerTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CommandDefinitionTokenizerTest.java
@@ -51,10 +51,31 @@ public class CommandDefinitionTokenizerTest {
         List<Token> tokens = this._tokenizer.tokenize(inputTokens);
 
         Assertions.assertTrue(tokens.size() == 4);
+        Assertions.assertEquals(Token.Type.COMMAND, tokens.get(0).getType());
         Assertions.assertTrue(tokens.get(0).getValue().equals("file"));
+        Assertions.assertEquals(Token.Type.REQUIRED_VALUE, tokens.get(1).getType());
         Assertions.assertTrue(tokens.get(1).getValue().equals("fileName1"));
+        Assertions.assertEquals(Token.Type.REGEX_VALUE, tokens.get(2).getType());
         Assertions.assertTrue(tokens.get(2).getValue().equals("file\\d.txt"));
+        Assertions.assertEquals(Token.Type.DESCRIPTION, tokens.get(3).getType());
         Assertions.assertTrue(tokens.get(3).getValue().equals("Load a files into the system"));
+    }
 
+    @Test
+    public void testTokenizerOptionalAndListTokenTypes() {
+        final String inputString = "cmd, ?optName, ?optNames..., !reqNames...";
+        final String[] inputTokens = inputString.split("\\s*,\\s*");
+
+        List<Token> tokens = this._tokenizer.tokenize(inputTokens);
+
+        Assertions.assertEquals(4, tokens.size());
+        Assertions.assertEquals(Token.Type.COMMAND, tokens.get(0).getType());
+        Assertions.assertEquals("cmd", tokens.get(0).getValue());
+        Assertions.assertEquals(Token.Type.OPTIONAL_VALUE, tokens.get(1).getType());
+        Assertions.assertEquals("optName", tokens.get(1).getValue());
+        Assertions.assertEquals(Token.Type.OPTIONAL_LIST_VALUE, tokens.get(2).getType());
+        Assertions.assertEquals("optNames", tokens.get(2).getValue());
+        Assertions.assertEquals(Token.Type.REQUIRED_LIST_VALUE, tokens.get(3).getType());
+        Assertions.assertEquals("reqNames", tokens.get(3).getValue());
     }
 }

--- a/src/test/java/com/gabstudios/cmdline/CommandTest.java
+++ b/src/test/java/com/gabstudios/cmdline/CommandTest.java
@@ -1,0 +1,103 @@
+/*****************************************************************************************
+ *
+ * Copyright 2016-2025 Gregory Brown. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ *****************************************************************************************
+ */
+
+package com.gabstudios.cmdline;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the {@link Command} class.
+ */
+public class CommandTest {
+
+    // -----------------------------------------------------------------------
+    // Positive tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testGetValuesReturnsEmptyListForUnknownVariable() {
+        final Command command = new Command("test");
+        final List<String> values = command.getValues("nonexistent");
+        Assertions.assertNotNull(values);
+        Assertions.assertTrue(values.isEmpty());
+    }
+
+    @Test
+    public void testAddVariableAccumulatesMultipleValuesForSameKey() {
+        final Command command = new Command("test");
+        command.addVariable("key", "value1");
+        command.addVariable("key", "value2");
+        final List<String> values = command.getValues("key");
+        Assertions.assertEquals(2, values.size());
+        Assertions.assertTrue(values.contains("value1"));
+        Assertions.assertTrue(values.contains("value2"));
+    }
+
+    @Test
+    public void testEqualCommandsHaveSameHashCode() {
+        final Command cmd1 = new Command("cmd");
+        final Command cmd2 = new Command("cmd");
+        Assertions.assertEquals(cmd1, cmd2);
+        Assertions.assertEquals(cmd1.hashCode(), cmd2.hashCode());
+    }
+
+    @Test
+    public void testCommandsWithDifferentNamesAreNotEqual() {
+        final Command cmd1 = new Command("cmd1");
+        final Command cmd2 = new Command("cmd2");
+        Assertions.assertNotEquals(cmd1, cmd2);
+    }
+
+    @Test
+    public void testHasVariablesReturnsFalseWhenNoVariablesAdded() {
+        final Command command = new Command("test");
+        Assertions.assertFalse(command.hasVariables());
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void testAddVariableNullNameThrowsIllegalArgumentException() {
+        final Command command = new Command("test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> command.addVariable(null, "value"));
+    }
+
+    @Test
+    public void testAddVariableEmptyNameThrowsIllegalArgumentException() {
+        final Command command = new Command("test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> command.addVariable("", "value"));
+    }
+
+    @Test
+    public void testAddVariableNullValueThrowsIllegalArgumentException() {
+        final Command command = new Command("test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> command.addVariable("key", null));
+    }
+
+    @Test
+    public void testAddVariableEmptyValueThrowsIllegalArgumentException() {
+        final Command command = new Command("test");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> command.addVariable("key", ""));
+    }
+}


### PR DESCRIPTION
## Summary

Turns `CmdLine` from a static singleton into an ordinary instance class, fixes four parser behaviours that were surprising rather than wrong-by-design, and repairs documentation that the refactor itself had left stale.

**This is an API break.** Java forbids a static and an instance method with the same signature, so no static facade was possible under the existing names. The version stays `1.0.0-SNAPSHOT` and nothing has been published to Maven Central, so no released consumer is affected.

## What changed

- **`CmdLine` is an instance class.** `new CmdLine()`, per-instance state, chaining returns `this`.
- **A description now terminates the definition split.** `#...` runs to end-of-string and may contain commas and `=`. Fixed in both entry paths — `splitDefinition` and the tokenizer.
- **`parse` accepts an empty array** and returns an empty list, with a new `MAX_ARGUMENTS` separate from `MAX_LENGTH`. Callers no longer need a no-args special case.
- **`!value` names are scoped per command** rather than globally unique, so two commands may each take a `!file`.
- **A listener applies to its own parse only** (saved and restored around the call).

## Documentation

The README still taught the static API and the class javadoc had been damaged by the refactor. Both repaired, along with `@return` tags left over from the singleton era. The README example was extracted, compiled and run to confirm it works as printed.

## Tests

64 → 75, including a new `CmdLineInstanceTest` (11 cases). Three existing tests encoded behaviour deliberately changed here and were updated. One failure was a real regression introduced during the work: trimming in the tokenizer made a whitespace-only definition produce zero tokens and silently define nothing — a guard now runs in `defineCommand` before `createCommandDefinition`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)